### PR TITLE
fix: use correct zensical emoji extension namespace

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -358,8 +358,8 @@ link = "https://github.com/aws/aws-durable-execution-docs"
 [project.markdown_extensions.pymdownx.details]
 [project.markdown_extensions.attr_list]
 [project.markdown_extensions.pymdownx.emoji]
-emoji_index = "material.extensions.emoji.twemoji"
-emoji_generator = "material.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+emoji_generator = "zensical.extensions.emoji.to_svg"
 [project.markdown_extensions.pymdownx.highlight]
 anchor_linenums = true
 line_spans = "__span"


### PR DESCRIPTION
*Description of changes:*
- Replace pymdownx.emoji namespace with zensical.extensions.emoji
- Required for icon support to work with Zensical's bundled extensions

*Issue #, if available:*




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
