### PR TITLE
docs: logging

### DIFF
--- a/docs/sdk-reference/observability/logging.md
+++ b/docs/sdk-reference/observability/logging.md
@@ -1,768 +1,407 @@
-# Logger integration
+# Logging
 
-The Durable Execution SDK automatically enriches your logs with execution context, making it easy to trace operations across checkpoints and replays. You can use the built-in logger or integrate with Powertools for AWS Lambda (Python) for advanced structured logging.
+## Replay-aware logger
 
-## Table of contents
+Use the Durable Execution SDK logger to add structured log entries to your function. The
+SDK automatically tags every entry with execution metadata such as the ARN, operation
+name, and retry attempt. The logger will not emit duplicate log entries on replay. The
+SDK provides a default logger, or you can [provide a custom logger](#custom-logger).
 
-- [Key features](#key-features)
-- [Terminology](#terminology)
-- [Getting started](#getting-started)
-- [Method signature](#method-signature)
-- [Automatic context enrichment](#automatic-context-enrichment)
-- [Adding custom metadata](#adding-custom-metadata)
-- [Logger inheritance in child contexts](#logger-inheritance-in-child-contexts)
-- [Integration with Powertools for AWS Lambda (Python)](#integration-with-powertools-for-aws-lambda-python)
-- [Replay behavior and log deduplication](#replay-behavior-and-log-deduplication)
-- [Best practices](#best-practices)
-- [Enabling debug logging](#enabling-debug-logging)
-- [FAQ](#faq)
-- [Testing logger integration](#testing-logger-integration)
-- [See also](#see-also)
-
-[← Back to main index](../index.md)
-
-## Key features
-
-- Automatic log deduplication during replays - logs from completed operations don't repeat
-- Automatic enrichment with execution context (execution ARN, parent ID, operation name, attempt number)
-- Logger inheritance in child contexts for hierarchical tracing
-- Compatible with Python's standard logging and Powertools for AWS Lambda (Python)
-- Support for custom metadata through the `extra` parameter
-- All standard log levels: debug, info, warning, error, exception
-
-[↑ Back to top](#table-of-contents)
-
-## Terminology
-
-**Log deduplication** - The SDK prevents duplicate logs during replays by tracking completed operations. When your function is checkpointed and resumed, logs from already-completed operations aren't emitted again, keeping your CloudWatch logs clean.
-
-**Context enrichment** - The automatic addition of execution metadata (execution ARN, parent ID, operation name, attempt number) to log entries. The SDK handles this for you, so every log includes tracing information.
-
-**Logger inheritance** - When you create a child context, it inherits the parent's logger and adds its own context information. This creates a hierarchical logging structure that mirrors your execution flow.
-
-**Extra metadata** - Additional key-value pairs you can add to log entries using the `extra` parameter. These merge with the automatic context enrichment.
-
-[↑ Back to top](#table-of-contents)
-
-## Getting started
-
-Access the logger through `context.logger` in your durable functions:
+The [Powertools for AWS Lambda logger](#powertools-for-aws-lambda) works as a
+replacement for the SDK's default logger. It adds structured JSON output, correlation
+IDs, log sampling, and X-Ray tracing integration.
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/basic-usage.ts"
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/basic-usage.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/basic-usage.py"
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/basic-usage.py"
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/basic-usage.java"
+    ```java
+    --8<-- "examples/java/sdk-reference/observability/basic-usage.java"
     ```
 
-
-The logger automatically includes execution context in every log entry.
-
-### Integration with Lambda Advanced Log Controls
-
-Durable functions work with Lambda's Advanced Log Controls. You can configure your Lambda function to filter logs by level, which helps reduce CloudWatch Logs costs and noise. When you set a log level filter (like INFO or ERROR), logs below that level are automatically ignored.
-
-For example, if you set your Lambda function's log level to INFO, debug logs won't appear in CloudWatch Logs:
+## Log methods
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/lambda-log-controls.ts"
+    ```typescript
+    // On DurableContext and StepContext:
+    context.logger.info(...params: unknown[]): void
+    context.logger.warn(...params: unknown[]): void
+    context.logger.error(...params: unknown[]): void
+    context.logger.debug(...params: unknown[]): void
+    context.logger.log(level: "INFO" | "WARN" | "ERROR" | "DEBUG", ...params: unknown[]): void
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/lambda-log-controls.py"
+    ```python
+    # On DurableContext and StepContext:
+    context.logger.debug(msg, *args, extra=None)
+    context.logger.info(msg, *args, extra=None)
+    context.logger.warning(msg, *args, extra=None)
+    context.logger.error(msg, *args, extra=None)
+    context.logger.exception(msg, *args, extra=None)
     ```
+
+    **Parameters (all log methods):**
+
+    - `msg` (`object`) The log message.
+    - `*args` (`object`) Arguments for message formatting, passed to the underlying logger.
+    - `extra` (`Mapping[str, object] | None`) Additional fields to include in the log entry.
+        These merge with the automatic context fields.
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/lambda-log-controls.java"
+    ```java
+    // Obtain from any context:
+    DurableLogger logger = context.getLogger();
+    DurableLogger logger = stepContext.getLogger();
+
+    // Available methods:
+    logger.trace(String format, Object... args)
+    logger.debug(String format, Object... args)
+    logger.info(String format, Object... args)
+    logger.warn(String format, Object... args)
+    logger.error(String format, Object... args)
+    logger.error(String message, Throwable t)
     ```
 
+    The Java logger uses SLF4J format strings. Pass `{}` placeholders and positional
+    arguments.
 
-Learn more about configuring log levels in the [Lambda Advanced Log Controls documentation](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs.html#monitoring-cloudwatchlogs-advanced).
-
-[↑ Back to top](#table-of-contents)
-
-## Method signature
-
-The logger provides standard logging methods:
+## Default log format
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/logger-method-signature.ts"
+    The default logger always emits structured JSON. A log entry from a step looks like:
+
+    ```json
+    {
+      "timestamp": "2025-11-21T18:39:24.743Z",
+      "level": "INFO",
+      "requestId": "72171fff-...",
+      "executionArn": "arn:aws:lambda:...",
+      "operationId": "abc123",
+      "operationName": "process",
+      "attempt": 1,
+      "message": "Running step"
+    }
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/logger-method-signature.py"
+    When your Lambda function's log format is set to JSON, the log output includes the extra
+    metadata as top-level keys in the JSON output. See
+    [Using Lambda advanced logging controls with Python](https://docs.aws.amazon.com/lambda/latest/dg/python-logging.html#python-logging-advanced).
+
+    ```json
+    {
+      "timestamp": "2025-11-21T18:39:24Z",
+      "level": "INFO",
+      "message": "Running step",
+      "requestId": "72171fff-...",
+      "executionArn": "arn:aws:lambda:...",
+      "operationId": "abc123",
+      "operationName": "process",
+      "attempt": 1
+    }
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/logger-method-signature.java"
+    Calling `getLogger()` populates SLF4J MDC with execution context fields. When your
+    Lambda function's log format is set to JSON and your logging framework includes MDC
+    fields in its output, those fields appear as top-level keys in the JSON log record. See
+    [Using Lambda advanced logging controls with Java](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html#java-logging-advanced).
+
+    Field names and structure depend on your logging framework configuration. A Log4j2 JSON
+    output might look like:
+
+    ```json
+    {
+      "timestamp": "2025-11-21T18:39:24.743Z",
+      "level": "INFO",
+      "message": "Running step",
+      "AWSRequestId": "72171fff-...",
+      "durableExecutionArn": "arn:aws:lambda:...",
+      "operationId": "abc123",
+      "operationName": "process",
+      "attempt": "1"
+    }
     ```
 
+## Execution metadata
 
-**Parameters:**
-- `msg` (object) - The log message. Can include format placeholders.
-- `*args` (object) - Arguments for message formatting.
-- `extra` (dict[str, object] | None) - Optional dictionary of additional fields to include in the log entry.
+The SDK automatically enriches log entries with execution metadata. The metadata varies
+depending on the logging context.
 
-[↑ Back to top](#table-of-contents)
+### DurableContext at handler level
 
-## Automatic context enrichment
+This is the `DurableContext` passed to the durable handler. It enriches the output with
+the following fields:
 
-The SDK automatically enriches logs with execution metadata:
+- `executionArn` (TypeScript, Python) / `durableExecutionArn` (Java MDC) the ARN of the
+    current durable execution
+- `requestId` the Lambda request ID
+
+### DurableContext (child)
+
+All DurableContext fields, plus:
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/automatic-context-enrichment.ts"
+    - `operationId` hashed ID of the child context operation
+
+=== "Python"
+
+    - `parentId` the operation ID of the current child context. Operations inside this child
+        context log both `parentId` (the containing child context) and `operationId` (the
+        operation itself).
+
+=== "Java"
+
+    - `contextId` the operation ID of the child context operation
+    - `contextName` the name given to the child context, when you provide one
+
+### Operation context
+
+The following operation contexts support the logger:
+
+- [StepContext](../operations/step.md#stepcontext)
+- [WaitForConditionContext](../operations/wait-for-condition.md#method-signature)
+- [WaitForCallbackContext](../operations/callback.md#waitforcallback)
+
+All DurableContext fields, plus:
+
+- `operationId` the unique ID of the operation
+- `operationName` the operation name, when you provide one
+- `attempt` the current retry attempt number (1-indexed, steps only)
+
+The following examples show logging from inside a step. Using the StepContext logger
+instead of DurableContext's logger adds step-specific fields (`operationId`,
+`operationName`, `attempt`) to every log entry from that step.
+
+=== "TypeScript"
+
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/step-context-logger.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/automatic-context-enrichment.py"
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/step-context-logger.py"
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/automatic-context-enrichment.java"
+    The Java SDK uses SLF4J MDC to attach fields. Configure your logging framework (e.g.
+    Logback, Log4j2) to include MDC fields in your log pattern.
+
+    ```java
+    --8<-- "examples/java/sdk-reference/observability/step-context-logger.java"
     ```
 
+## Replay log suppression
 
-**Enriched fields:**
-- `execution_arn` - Always present, identifies the durable execution
-- `parent_id` - Present in child contexts, identifies the parent operation
-- `name` - Present when the operation has a name
-- `attempt` - Present in steps, shows the retry attempt number
+When the SDK replays, it runs your handler from the start until it reaches the next
+incomplete operation. It does not re-emit log entries encountered before that point,
+since these already emitted on the first invocation that traversed them.
 
-[↑ Back to top](#table-of-contents)
-
-## Adding custom metadata
-
-Use the `extra` parameter to add custom fields to your logs:
+Logs inside a retrying step body always emit, because the step has not completed yet.
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/add-custom-metadata.ts"
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/replay-suppression.ts"
+    ```
+
+    Pass `modeAware: false` to `configureLogger` to emit logs on every replay.
+
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/disable-replay-suppression.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/add-custom-metadata.py"
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/replay-suppression.py"
     ```
+
+    The Python SDK checks `execution_state.is_replaying()` before each log call. You cannot
+    disable this per-context, but you can log directly to the underlying logger to bypass
+    it.
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/add-custom-metadata.java"
+    ```java
+    --8<-- "examples/java/sdk-reference/observability/replay-suppression.java"
     ```
 
+    Pass `LoggerConfig.withReplayLogging()` to `DurableConfig` to emit logs on every replay.
+    See [Configure logger](#configure-logger).
 
-Custom fields merge with the automatic context enrichment, so your logs include both execution metadata and your custom data.
+## Custom logger
 
-[↑ Back to top](#table-of-contents)
-
-## Logger inheritance in child contexts
-
-Child contexts inherit the parent's logger and add their own context:
+You can replace the default logger with any logger that implements the SDK's logger
+interface.
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/child-workflow.ts"
+    Any object that implements `DurableLogger` works. Pass it to `configureLogger`.
+
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/custom-logger.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/child-workflow.py"
+    Any object that satisfies the `LoggerInterface` protocol works. Pass it to
+    `context.set_logger()`.
+
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/custom-logger.py"
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/child-workflow.java"
-    ```
+    The Java SDK does not support swapping the underlying logger. `getLogger()` always wraps
+    an SLF4J logger obtained from `LoggerFactory`. To change logging behavior, configure
+    your SLF4J implementation (Logback, Log4j2) or adjust `LoggerConfig` via
+    `DurableConfig`. See [Configure logger](#configure-logger).
 
-
-This creates a hierarchical logging structure where you can trace operations from parent to child contexts.
-
-[↑ Back to top](#table-of-contents)
-
-## Integration with Powertools for AWS Lambda (Python)
-
-The SDK is compatible with Powertools for AWS Lambda (Python), giving you structured logging with JSON output and additional features.
-
-**Powertools for AWS Lambda (Python) benefits:**
-- JSON structured logging for CloudWatch Logs Insights
-- Automatic Lambda context injection (request ID, function name, etc.)
-- Correlation IDs for distributed tracing
-- Log sampling for cost optimization
-- Integration with X-Ray tracing
-
-### Using Powertools for AWS Lambda (Python) directly
-
-You can use Powertools for AWS Lambda (Python) directly in your durable functions:
+## Configure logger
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/child-workflow.ts"
+    Configure the logger on the handler's `DurableContext`.
+
+    ```typescript
+    context.configureLogger(config: LoggerConfig): void
+    ```
+
+    **`LoggerConfig`**
+
+    ```typescript
+    interface LoggerConfig<Logger extends DurableLogger> {
+      customLogger?: Logger;
+      modeAware?: boolean;
+    }
+    ```
+
+    **`LoggerConfig` parameters:**
+
+    - `customLogger` (optional) A [`DurableLogger`](#logger-interface) implementation to use
+        instead of the default console logger.
+    - `modeAware` (optional) When `true` (default), the SDK suppresses logs during replay.
+        Set to `false` to emit logs on every replay.
+
+=== "Python"
+
+    Set the logger on the handler's `DurableContext`.
+
+    ```python
+    context.set_logger(new_logger: LoggerInterface) -> None
+    ```
+
+    Pass any object that satisfies the [`LoggerInterface`](#logger-interface) protocol.
+
+=== "Java"
+
+    Configure replay suppression via `LoggerConfig` on `DurableConfig`.
+
+    **`LoggerConfig`**
+
+    ```java
+    public record LoggerConfig(boolean suppressReplayLogs) {
+        public static LoggerConfig defaults()          // suppress replay logs (default)
+        public static LoggerConfig withReplayLogging() // allow logs during replay
+    }
+    ```
+
+    **`LoggerConfig` parameters:**
+
+    - `suppressReplayLogs` (`boolean`) When `true` (default), the SDK suppresses logs during
+        replay. Use `LoggerConfig.withReplayLogging()` to set this to `false`.
+
+    ```java
+    DurableConfig.builder()
+        .withLoggerConfig(LoggerConfig.withReplayLogging())
+        .build();
+    ```
+
+## Logger interface
+
+=== "TypeScript"
+
+    `DurableLogger` is the interface a custom logger must implement.
+
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/logger-interface.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/child-workflow.py"
+    `LoggerInterface` is the protocol a custom logger must satisfy.
+
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/logger-interface.py"
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/child-workflow.java"
-    ```
+    The Java SDK wraps any SLF4J `Logger` in `DurableLogger`. There is no interface to
+    implement.
 
+## Powertools for AWS Lambda
 
-This gives you all Powertools for AWS Lambda (Python) features like JSON logging and correlation IDs.
-
-### Integrating with context.logger
-
-For better integration with durable execution, set Powertools for AWS Lambda (Python) on the context:
+[Powertools for AWS Lambda](https://docs.aws.amazon.com/powertools/) provides a
+structured logger that works as a drop-in replacement for the SDK's default logger.
 
 === "TypeScript"
 
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/integrate-powertools-context.ts"
+    The
+    [Powertools for AWS Lambda (TypeScript)](https://docs.aws.amazon.com/powertools/typescript/latest/features/logger/)
+    `Logger` satisfies the `DurableLogger` interface. Pass it via `configureLogger`.
+
+    ```typescript
+    --8<-- "examples/typescript/sdk-reference/observability/powertools-logger.ts"
     ```
 
 === "Python"
 
-    ``` python
-    --8<-- "examples/python/core/logger/integrate-powertools-context.py"
+    The
+    [Powertools for AWS Lambda (Python)](https://docs.aws.amazon.com/powertools/python/latest/core/logger/)
+    `Logger` satisfies the `LoggerInterface` protocol. Pass it via `context.set_logger()`.
+
+    ```python
+    --8<-- "examples/python/sdk-reference/observability/powertools-logger.py"
     ```
 
 === "Java"
 
-    ``` java
-    --8<-- "examples/java/core/logger/integrate-powertools-context.java"
+    The
+    [Powertools for AWS Lambda (Java) logger](https://docs.aws.amazon.com/powertools/java/latest/core/logging/)
+    uses SLF4J, which is the same logging facade the SDK wraps. Add Powertools as your SLF4J
+    implementation and the SDK's `getLogger()` will automatically use it. No additional
+    wiring is required.
+
+    ```java
+    --8<-- "examples/java/sdk-reference/observability/powertools-logger.java"
     ```
-
-
-**Benefits of using context.logger:**
-- All Powertools for AWS Lambda (Python) features (JSON logging, correlation IDs, etc.)
-- Automatic SDK context enrichment (execution_arn, parent_id, name, attempt)
-- Log deduplication during replays (see next section)
-
-The SDK's context enrichment (execution_arn, parent_id, name, attempt) merges with Powertools for AWS Lambda (Python) fields (service, request_id, function_name, etc.) in the JSON output.
-
-[↑ Back to top](#table-of-contents)
-
-## Replay behavior and log deduplication
-
-A critical feature of `context.logger` is that it prevents duplicate logs during replays. When your durable function is checkpointed and resumed, the SDK replays your code to reach the next operation, but logs from completed operations aren't emitted again.
-
-### How context.logger prevents duplicate logs
-
-When you use `context.logger`, the SDK tracks which operations have completed and suppresses logs during replay:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/context-logger-deduplication.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/context-logger-deduplication.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/context-logger-deduplication.java"
-    ```
-
-
-**What happens during replay:**
-1. First invocation: All logs appear (starting workflow, step 1 completed, step 2 completed)
-2. After checkpoint and resume: Only new logs appear (step 2 completed if step 1 was checkpointed)
-3. Your CloudWatch logs show each message only once, making them clean and easy to read
-
-### Logging behavior with direct logger usage
-
-When you use a logger directly (not through `context.logger`), logs will be emitted on every replay:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/direct-logger-duplicates.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/direct-logger-duplicates.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/direct-logger-duplicates.java"
-    ```
-
-
-**What happens during replay:**
-1. First invocation: All logs appear once
-2. After checkpoint and resume: "Starting workflow" and "Step 1 completed" appear again
-3. Your CloudWatch logs show duplicate entries for replayed operations
-
-### Using context.logger with Powertools for AWS Lambda (Python)
-
-To get both log deduplication and Powertools for AWS Lambda (Python) features, set the Powertools Logger on the context:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/powertools-with-deduplication.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/powertools-with-deduplication.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/powertools-with-deduplication.java"
-    ```
-
-
-**Benefits of this approach:**
-- Clean logs without duplicates during replays
-- JSON structured logging from Powertools for AWS Lambda (Python)
-- Automatic context enrichment from the SDK (execution_arn, parent_id, name, attempt)
-- Lambda context injection from Powertools for AWS Lambda (Python) (request_id, function_name, etc.)
-- Correlation IDs and X-Ray integration from Powertools for AWS Lambda (Python)
-
-### When you might see duplicate logs
-
-You'll still see duplicate logs in these scenarios:
-- Logs from operations that fail and retry (this is expected and helpful for debugging)
-- Logs outside of durable execution context (before `@durable_execution` decorator runs)
-- Logs from code that runs during replay before reaching a checkpoint
-
-This is normal behavior and helps you understand the execution flow.
-
-[↑ Back to top](#table-of-contents)
-
-## Best practices
-
-**Use structured logging with extra fields**
-
-Add context-specific data through the `extra` parameter rather than embedding it in the message string:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/structured-logging-extra.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/structured-logging-extra.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/structured-logging-extra.java"
-    ```
-
-
-**Log at appropriate levels**
-
-- `debug` - Detailed diagnostic information for troubleshooting
-- `info` - General informational messages about workflow progress
-- `warning` - Unexpected situations that don't prevent execution
-- `error` - Error conditions that may need attention
-- `exception` - Exceptions with stack traces (use in except blocks)
-
-**Include business context in logs**
-
-Add identifiers that help you trace business operations:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/include-business-context.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/include-business-context.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/include-business-context.java"
-    ```
-
-
-**Use Powertools for AWS Lambda (Python) for production**
-
-For production workloads, use Powertools for AWS Lambda (Python) to get JSON structured logging and CloudWatch Logs Insights integration:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/use-powertools-production.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/use-powertools-production.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/use-powertools-production.java"
-    ```
-
-
-**Don't log sensitive data**
-
-Avoid logging sensitive information like passwords, tokens, or personal data:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/avoid-sensitive-data.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/avoid-sensitive-data.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/avoid-sensitive-data.java"
-    ```
-
-
-[↑ Back to top](#table-of-contents)
-
-## Enabling debug logging
-
-The SDK logs internally using Python's standard `logging` module. To see these logs, set `ApplicationLogLevel: DEBUG` in [Advanced logging controls](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-advanced.html).
-
-Advanced logging controls filters logs before they reach CloudWatch. If you set DEBUG level in code but leave Advanced logging controls at INFO, your debug logs will be dropped. You must configure the level in Advanced logging controls - it auto-patches all loggers, so you don't need to configure log levels in code.
-
-```mermaid
-flowchart LR
-    A[Logger emits DEBUG] --> B{Advanced Logging Controls}
-    B -->|ApplicationLogLevel = DEBUG| C[CloudWatch ✓]
-    B -->|ApplicationLogLevel = INFO| D[Dropped ✗]
-```
-
-**Important:** DEBUG level applies to all libraries including botocore. Since the SDK uses boto3 internally, this will flood your logs with HTTP request/response details. Silence botocore in your code:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/silence-botocore.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/silence-botocore.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/silence-botocore.java"
-    ```
-
-
-Configure ALC via SAM/CloudFormation:
-
-```yaml
-# SAM template
-Resources:
-  MyFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      LoggingConfig:
-        LogFormat: JSON
-        ApplicationLogLevel: DEBUG
-```
-
-Or in the Lambda console under Configuration → Monitoring and operations tools → Logging configuration.
-
-### Selective logging
-
-Python loggers are hierarchical. Silencing `aws_durable_execution_sdk_python` silences all SDK modules. To keep some modules at DEBUG while silencing others:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/selective-logging.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/selective-logging.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/selective-logging.java"
-    ```
-
-
-SDK logger namespaces:
-
-| Namespace | Description |
-|-----------|-------------|
-| `aws_durable_execution_sdk_python` | Root - silences all SDK logs |
-| `aws_durable_execution_sdk_python.state` | Checkpoint and replay state management |
-| `aws_durable_execution_sdk_python.execution` | Durable execution lifecycle |
-| `aws_durable_execution_sdk_python.context` | DurableContext operations |
-| `aws_durable_execution_sdk_python.lambda_service` | Lambda API calls |
-| `aws_durable_execution_sdk_python.serdes` | Serialization/deserialization |
-| `aws_durable_execution_sdk_python.concurrency` | Parallel and map execution |
-| `aws_durable_execution_sdk_python.operation.step` | Step operations |
-| `aws_durable_execution_sdk_python.operation.wait` | Wait operations |
-| `aws_durable_execution_sdk_python.operation.invoke` | Invoke operations |
-| `aws_durable_execution_sdk_python.operation.child` | Child context operations |
-| `aws_durable_execution_sdk_python.operation.parallel` | Parallel operations |
-| `aws_durable_execution_sdk_python.operation.map` | Map operations |
-
-[↑ Back to top](#table-of-contents)
-
-## FAQ
-
-**Q: Does logging work during replays?**
-
-Yes, but `context.logger` prevents duplicate logs. When you use `context.logger`, the SDK tracks completed operations and suppresses their logs during replay. This keeps your CloudWatch logs clean and easy to read. If you use a logger directly (not through `context.logger`), you'll see duplicate log entries on every replay.
-
-**Q: How do I filter logs by execution?**
-
-Use the `execution_arn` field that's automatically added to every log entry. In CloudWatch Logs Insights:
-
-```
-fields @timestamp, @message, execution_arn
-| filter execution_arn = "arn:aws:lambda:us-east-1:123456789012:function:my-function:execution-id"
-| sort @timestamp asc
-```
-
-**Q: Can I use a custom logger?**
-
-Yes. Any logger that implements the `LoggerInterface` protocol works with the SDK. Use `context.set_logger()` to set your custom logger.
-
-The protocol is defined in `aws_durable_execution_sdk_python.types`:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/logger-interface-protocol.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/logger-interface-protocol.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/logger-interface-protocol.java"
-    ```
-
-
-Any logger with these methods (like Python's standard `logging.Logger` or Powertools Logger) is compatible.
-
-**Q: What's the difference between the SDK logger and Powertools for AWS Lambda (Python)?**
-
-The SDK provides a logger wrapper that adds execution context. Powertools for AWS Lambda (Python) provides structured JSON logging and Lambda-specific features. You can use them together - set the Powertools Logger on the context, and the SDK will enrich it with execution metadata.
-
-**Q: Do child contexts get their own logger?**
-
-Child contexts inherit the parent's logger and add their own `parent_id` to the context. This creates a hierarchical logging structure where you can trace operations from parent to child.
-
-**Q: How do I change the log level?**
-
-If using Python's standard logging, configure it before your handler:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/set-standard-log-level.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/set-standard-log-level.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/set-standard-log-level.java"
-    ```
-
-
-If using Powertools for AWS Lambda (Python), set the level when creating the logger:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/set-powertools-log-level.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/set-powertools-log-level.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/set-powertools-log-level.java"
-    ```
-
-
-**Q: Can I access the underlying logger?**
-
-Yes. Use `context.logger.get_logger()` to access the underlying logger instance if you need to call methods not in the `LoggerInterface`.
-
-[↑ Back to top](#table-of-contents)
-
-## Testing logger integration
-
-You can verify that your durable functions log correctly by capturing log output in tests.
-
-### Example test
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/test-basic-logger.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/test-basic-logger.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/test-basic-logger.java"
-    ```
-
-
-### Verifying log output
-
-To verify specific log messages, capture log output using Python's logging test utilities:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/test-verify-log-output.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/test-verify-log-output.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/test-verify-log-output.java"
-    ```
-
-
-### Testing with Powertools for AWS Lambda (Python)
-
-When testing with Powertools for AWS Lambda (Python), you can verify structured log output:
-
-=== "TypeScript"
-
-    ``` typescript
-    --8<-- "examples/typescript/core/logger/test-with-powertools.ts"
-    ```
-
-=== "Python"
-
-    ``` python
-    --8<-- "examples/python/core/logger/test-with-powertools.py"
-    ```
-
-=== "Java"
-
-    ``` java
-    --8<-- "examples/java/core/logger/test-with-powertools.java"
-    ```
-
-
-[↑ Back to top](#table-of-contents)
 
 ## See also
 
-- [Steps](steps.md) - Learn about step operations that use logger enrichment
-- [Child contexts](child-contexts.md) - Understand logger inheritance in nested contexts
-- [Getting started](../getting-started.md) - Basic durable function setup
-- [Powertools for AWS Lambda (Python) - Logger](https://docs.powertools.aws.dev/lambda/python/latest/core/logger/) - Powertools Logger documentation
-
-[↑ Back to top](#table-of-contents)
-
-## License
-
-See the LICENSE file for our project's licensing.
-
-[↑ Back to top](#table-of-contents)
+- [Steps](../operations/step.md)
+- [Child contexts](../operations/child-contexts.md)
+- [Error handling](error-handling.md)

--- a/examples/java/sdk-reference/observability/basic-usage.java
+++ b/examples/java/sdk-reference/observability/basic-usage.java
@@ -1,0 +1,14 @@
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+public class BasicUsage extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object event, DurableContext context) {
+        context.getLogger().info("Starting workflow");
+
+        String result = context.step("process", String.class, stepCtx -> "done");
+
+        context.getLogger().info("Workflow complete: {}", result);
+        return result;
+    }
+}

--- a/examples/java/sdk-reference/observability/custom-logger.java
+++ b/examples/java/sdk-reference/observability/custom-logger.java
@@ -1,0 +1,21 @@
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.logging.LoggerConfig;
+
+public class CustomLogger extends DurableHandler<Object, Void> {
+
+    @Override
+    protected DurableConfig createConfiguration() {
+        // Allow logs during replay by overriding the default LoggerConfig.
+        return DurableConfig.builder()
+                .withLoggerConfig(LoggerConfig.withReplayLogging())
+                .build();
+    }
+
+    @Override
+    public Void handleRequest(Object event, DurableContext context) {
+        context.getLogger().info("Logs appear on every replay");
+        return null;
+    }
+}

--- a/examples/java/sdk-reference/observability/logger-interface.java
+++ b/examples/java/sdk-reference/observability/logger-interface.java
@@ -1,0 +1,17 @@
+import org.slf4j.Logger;
+import software.amazon.lambda.durable.logging.DurableLogger;
+
+// DurableLogger wraps an SLF4J Logger and adds MDC entries:
+//   durableExecutionArn, requestId, operationId, operationName, attempt
+//
+// Obtain it from any context:
+//   DurableLogger logger = context.getLogger();
+//   DurableLogger logger = stepContext.getLogger();
+//
+// Available methods:
+//   logger.trace(String format, Object... args)
+//   logger.debug(String format, Object... args)
+//   logger.info(String format, Object... args)
+//   logger.warn(String format, Object... args)
+//   logger.error(String format, Object... args)
+//   logger.error(String message, Throwable t)

--- a/examples/java/sdk-reference/observability/powertools-logger.java
+++ b/examples/java/sdk-reference/observability/powertools-logger.java
@@ -1,0 +1,16 @@
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.lambda.powertools.logging.Logging;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class MyHandler implements RequestHandler<Object, String> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MyHandler.class);
+
+    @Logging
+    public String handleRequest(Object event, Context context) {
+        logger.info("Running handler");
+        return "ok";
+    }
+}

--- a/examples/java/sdk-reference/observability/replay-suppression.java
+++ b/examples/java/sdk-reference/observability/replay-suppression.java
@@ -1,0 +1,16 @@
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+
+public class ReplaySuppression extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object event, DurableContext context) {
+        // context.getLogger() suppresses duplicate logs during replay by default.
+        // Logs from completed operations do not repeat when the SDK replays.
+        context.getLogger().info("Step 1 starting");
+
+        String result = context.step("step-1", String.class, stepCtx -> "result");
+
+        context.getLogger().info("Step 1 complete: {}", result);
+        return result;
+    }
+}

--- a/examples/java/sdk-reference/observability/step-context-logger.java
+++ b/examples/java/sdk-reference/observability/step-context-logger.java
@@ -1,0 +1,14 @@
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.StepContext;
+
+public class StepContextLogger extends DurableHandler<Object, String> {
+    @Override
+    public String handleRequest(Object event, DurableContext context) {
+        return context.step("process", String.class, (StepContext stepCtx) -> {
+            // stepCtx.getLogger() includes operationId, operationName, and attempt in MDC.
+            stepCtx.getLogger().info("Running step");
+            return "done";
+        });
+    }
+}

--- a/examples/python/sdk-reference/observability/basic-usage.py
+++ b/examples/python/sdk-reference/observability/basic-usage.py
@@ -1,0 +1,11 @@
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext):
+    context.logger.info("Starting workflow")
+
+    result = context.step(lambda ctx: "done")
+
+    context.logger.info("Workflow complete", extra={"result": result})
+    return result

--- a/examples/python/sdk-reference/observability/custom-logger.py
+++ b/examples/python/sdk-reference/observability/custom-logger.py
@@ -1,0 +1,11 @@
+from aws_lambda_powertools import Logger
+
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+
+powertools_logger = Logger(service="my-service")
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext):
+    context.set_logger(powertools_logger)
+    context.logger.info("Using Powertools logger")

--- a/examples/python/sdk-reference/observability/logger-interface.py
+++ b/examples/python/sdk-reference/observability/logger-interface.py
@@ -1,0 +1,24 @@
+from collections.abc import Mapping
+from typing import Protocol
+
+
+class LoggerInterface(Protocol):
+    def debug(
+        self, msg: object, *args: object, extra: Mapping[str, object] | None = None
+    ) -> None: ...
+
+    def info(
+        self, msg: object, *args: object, extra: Mapping[str, object] | None = None
+    ) -> None: ...
+
+    def warning(
+        self, msg: object, *args: object, extra: Mapping[str, object] | None = None
+    ) -> None: ...
+
+    def error(
+        self, msg: object, *args: object, extra: Mapping[str, object] | None = None
+    ) -> None: ...
+
+    def exception(
+        self, msg: object, *args: object, extra: Mapping[str, object] | None = None
+    ) -> None: ...

--- a/examples/python/sdk-reference/observability/powertools-logger.py
+++ b/examples/python/sdk-reference/observability/powertools-logger.py
@@ -1,0 +1,11 @@
+from aws_lambda_powertools import Logger
+
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+
+powertools_logger = Logger(service="my-service")
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext):
+    context.set_logger(powertools_logger)
+    context.logger.info("Running handler")

--- a/examples/python/sdk-reference/observability/replay-suppression.py
+++ b/examples/python/sdk-reference/observability/replay-suppression.py
@@ -1,0 +1,13 @@
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext):
+    # context.logger suppresses duplicate logs during replay by default.
+    # Logs from completed operations do not repeat when the SDK replays.
+    context.logger.info("Step 1 starting")
+
+    result = context.step(lambda ctx: "result")
+
+    context.logger.info("Step 1 complete", extra={"result": result})
+    return result

--- a/examples/python/sdk-reference/observability/step-context-logger.py
+++ b/examples/python/sdk-reference/observability/step-context-logger.py
@@ -1,0 +1,11 @@
+from aws_durable_execution_sdk_python import DurableContext, StepContext, durable_execution
+
+
+@durable_execution
+def handler(event: dict, context: DurableContext):
+    def process(step_ctx: StepContext) -> str:
+        # step_ctx.logger includes executionArn, operationId, and attempt.
+        step_ctx.logger.info("Running step")
+        return "done"
+
+    return context.step(process, name="process")

--- a/examples/typescript/sdk-reference/observability/basic-usage.ts
+++ b/examples/typescript/sdk-reference/observability/basic-usage.ts
@@ -1,0 +1,12 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  context.logger.info("Starting workflow");
+
+  const result = await context.step("process", async () => {
+    return "done";
+  });
+
+  context.logger.info("Workflow complete", { result });
+  return result;
+});

--- a/examples/typescript/sdk-reference/observability/custom-logger.ts
+++ b/examples/typescript/sdk-reference/observability/custom-logger.ts
@@ -1,0 +1,9 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const powertoolsLogger = new Logger({ serviceName: "my-service" });
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  context.configureLogger({ customLogger: powertoolsLogger });
+  context.logger.info("Using Powertools logger");
+});

--- a/examples/typescript/sdk-reference/observability/disable-replay-suppression.ts
+++ b/examples/typescript/sdk-reference/observability/disable-replay-suppression.ts
@@ -1,0 +1,12 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  // Pass modeAware: false to emit logs on every replay.
+  context.configureLogger({ modeAware: false });
+
+  context.logger.info("This logs on every replay");
+
+  await context.step("step-1", async () => {
+    return "result";
+  });
+});

--- a/examples/typescript/sdk-reference/observability/logger-interface.ts
+++ b/examples/typescript/sdk-reference/observability/logger-interface.ts
@@ -1,0 +1,11 @@
+import { DurableLogger, DurableLoggingContext } from "@aws/durable-execution-sdk-js";
+
+// DurableLogger interface — implement this to use a custom logger.
+interface DurableLogger {
+  log?(level: "INFO" | "WARN" | "ERROR" | "DEBUG", ...params: unknown[]): void;
+  error(...params: unknown[]): void;
+  warn(...params: unknown[]): void;
+  info(...params: unknown[]): void;
+  debug(...params: unknown[]): void;
+  configureDurableLoggingContext?(context: DurableLoggingContext): void;
+}

--- a/examples/typescript/sdk-reference/observability/powertools-logger.ts
+++ b/examples/typescript/sdk-reference/observability/powertools-logger.ts
@@ -1,0 +1,9 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+const powertoolsLogger = new Logger({ serviceName: 'my-service' });
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  context.configureLogger({ customLogger: powertoolsLogger });
+  context.logger.info('Running handler');
+});

--- a/examples/typescript/sdk-reference/observability/replay-suppression.ts
+++ b/examples/typescript/sdk-reference/observability/replay-suppression.ts
@@ -1,0 +1,13 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  // context.logger suppresses duplicate logs during replay by default.
+  // Logs from completed operations do not repeat when the SDK replays.
+  context.logger.info("Step 1 starting");
+
+  await context.step("step-1", async () => {
+    return "result";
+  });
+
+  context.logger.info("Step 1 complete");
+});

--- a/examples/typescript/sdk-reference/observability/step-context-logger.ts
+++ b/examples/typescript/sdk-reference/observability/step-context-logger.ts
@@ -1,0 +1,9 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  await context.step("process", async (stepCtx) => {
+    // stepCtx.logger includes operationId and attempt in every log entry.
+    stepCtx.logger.info("Running step");
+    return "done";
+  });
+});


### PR DESCRIPTION
*Description of changes:*

- Restructure page with clear section order: log methods, default log format, execution metadata, replay suppression, custom logger, configure logger, logger interface, and Powertools
- Add per-language default log format examples with JSON output
- Add execution metadata section with per-context field reference and per-language tabs for child context fields
- Clarify replay suppression behaviour including retrying steps
- Add Configure logger and Logger interface as separate sections
- Add Powertools for AWS Lambda section with drop-in examples for all three languages
- Fix opening paragraph to be language-neutral
- Remove emdashes from list items

*Issue #, if available:*
Closes #37, Closes #73, Closes #55






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
