### PR TITLE
docs: rename durable-functions to durable-execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS Lambda durable functions developer documentation source
 
-This repository contains the source for the AWS Lambda durable functions SDK
-documentation website at https://docs.aws.amazon.com/durable-functions,
+This repository contains the source for the AWS Lambda Durable Execution SDK
+documentation website at https://docs.aws.amazon.com/durable-execution,
 providing comprehensive guides and references for building resilient,
 long-running applications with AWS Lambda durable functions across
 multiple programming languages.

--- a/zensical.toml
+++ b/zensical.toml
@@ -27,7 +27,7 @@ site_author = "AWS"
 # The site_url is the canonical URL for your site. When building online
 # documentation you should set this.
 # Read more: https://zensical.org/docs/setup/basics/#site_url
-site_url = "https://docs.aws.amazon.com/durable-functions"
+site_url = "https://docs.aws.amazon.com/durable-execution"
 
 repo_url = "https://github.com/aws/aws-durable-execution-docs"
 edit_uri = "edit/main/docs/"


### PR DESCRIPTION
*Description of changes:*
Rename site name to durable-execution from durable-functions

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
