### PR TITLE
feat: add s_code and Shortbread analytics

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
+  <link href="https://prod.assets.shortbread.aws.dev/shortbread.css" rel="stylesheet">
+  <script src="https://prod.assets.shortbread.aws.dev/shortbread.js"></script>
+  <script>
+    var shortbread = AWSCShortbread();
+    shortbread.checkForCookieConsent();
+  </script>
+{% endblock %}

--- a/zensical.toml
+++ b/zensical.toml
@@ -37,6 +37,9 @@ edit_uri = "edit/main/docs/"
 #
 # Read more: https://zensical.org/docs/setup/basics/#copyright
 copyright = """
+<a href="https://aws.amazon.com/privacy/">Privacy</a> |
+<a href="https://aws.amazon.com/terms/">Site terms</a> |
+<a href="#" id="awsccc-sb-ux-c-customize" onclick="if(typeof shortbread!=='undefined'){shortbread.customizeCookies()}return false;">Cookie preferences</a> |
 Copyright &copy; 2026 Amazon Web Services, Inc. or its affiliates.
 """
 
@@ -148,7 +151,7 @@ extra_css = ["stylesheets/extra.css"]
 # Read more:
 # - https://zensical.org/docs/customization/#extending-the-theme
 #
-#custom_dir = "overrides"
+custom_dir = "overrides"
 
 # With the "favicon" option you can set your own image to use as the icon
 # browsers will use in the browser title bar or tab bar. The path provided


### PR DESCRIPTION
- Add s_code (Adobe Analytics) via CDN in <head>
- Add Shortbread cookie consent library via CDN
- Add legal zone links (Privacy, Site terms, Cookie preferences) to footer
- Enable Zensical template overrides



*Issue #, if available:*
closes #150

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
