### PR TITLE
docs: fix hasFailure from method call to property access

### DIFF
--- a/aws-lambda-durable-functions-power/steering/concurrent-operations.md
+++ b/aws-lambda-durable-functions-power/steering/concurrent-operations.md
@@ -201,7 +201,7 @@ console.log(results.totalCount);       // Total items
 console.log(results.startedCount);     // Items started
 console.log(results.successCount);     // Successful items
 console.log(results.failureCount);     // Failed items
-console.log(results.hasFailure());     // Boolean
+console.log(results.hasFailure);     // Boolean
 ```
 
 ### Get Results
@@ -237,7 +237,7 @@ const all = results.all.map(item => ({
 ```typescript
 const results = await context.map('process', items, processFunc);
 
-if (results.hasFailure()) {
+if (results.hasFailure) {
   context.logger.error('Some items failed', {
     failureCount: results.failureCount,
     failures: results.failed.map(f => f.index)

--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -392,7 +392,7 @@ export const handler = withDurableExecution(async (event, context: DurableContex
     }
   );
 
-  if (results.hasFailure()) {
+  if (results.hasFailure) {
     // Log failures but continue
     context.logger.warn('Some items failed', {
       failureCount: results.failureCount,

--- a/aws-lambda-durable-functions-power/steering/testing-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/testing-patterns.md
@@ -19,7 +19,7 @@ Test durable functions locally and in the cloud with comprehensive test runners.
 - ✅ Python: Use `result.operations` to iterate and filter operations by type
 - ✅ Python: Instantiate `DurableFunctionTestRunner(handler=my_handler)` directly
 - ✅ Python: Use `runner.run(input={...}, timeout=10)` — note `input=` not `payload`
-- ✅ Python: The value of result.result is serialized. Deserialize using the appropriate SerDes or default json deserializer. 
+- ✅ Python: The value of result.result is serialized. Deserialize using the appropriate SerDes or default json deserializer.
 
 ### DON'T:
 
@@ -383,7 +383,7 @@ it('should fail after max retries', async () => {
   const execution = await runner.run({ payload: {} });
 
   expect(execution.getStatus()).toBe('FAILED');
-  expect(execution.getError()?.message).toContain('Permanent failure');
+  expect(execution.getError()?.errorMessage).toContain('Permanent failure');
 });
 ```
 


### PR DESCRIPTION
Updates documentation to use `results.hasFailure` (property) instead of `results.hasFailure()` (method call) in concurrent-operations and error-handling steering docs.