### PR TITLE
docs(power): update createClassSerdesWithDates example to use no-arg constructor

### DIFF
--- a/aws-lambda-durable-functions-power/steering/step-operations.md
+++ b/aws-lambda-durable-functions-power/steering/step-operations.md
@@ -227,13 +227,6 @@ For complex types, provide custom serialization:
 import { createClassSerdesWithDates } from '@aws/durable-execution-sdk-js';
 
 class User {
-  constructor(
-    public id: string,
-    public name: string,
-    public createdAt: Date
-  ) {}
-}
-class User {
   id: string = '';
   name: string = '';
   createdAt: Date = new Date();

--- a/aws-lambda-durable-functions-power/steering/step-operations.md
+++ b/aws-lambda-durable-functions-power/steering/step-operations.md
@@ -233,6 +233,11 @@ class User {
     public createdAt: Date
   ) {}
 }
+class User {
+  id: string = '';
+  name: string = '';
+  createdAt: Date = new Date();
+}
 
 const userSerdes = createClassSerdesWithDates(User, ['createdAt']);
 


### PR DESCRIPTION
# Issue

The createClassSerdesWithDates function requires a no-argument constructor (new () => T) as defined in the [SDK type signature](https://github.com/aws/aws-durable-execution-sdk-js/blob/88b945b16eaf5f3ac670302407a4de66d4af1df3/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts#L108):

```
export declare function createClassSerdesWithDates<T extends object>(
  cls: new () => T,  // zero-argument constructor required
  dateProps: string[]
): Serdes<T>;

```

The JSDoc also explicitly states: "The class constructor (must have no required parameters)"

The current example uses a constructor with 3 required parameters, which causes a TypeScript compile error:
```
Argument of type 'typeof User' is not assignable to parameter of type 'new () => User'.
Target signature provides too few arguments. Expected 3 or more, but got 0.
```


### Description of changes:

Updated createClassSerdesWithDates example to use no-arg constructor.
