### PR TITLE
docs(power): update createClassSerdes and createClassSerdesWithDates example to use no-arg constructor

### DIFF
--- a/aws-lambda-durable-functions-power/steering/advanced-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/advanced-patterns.md
@@ -247,9 +247,10 @@ import {
 } from '@aws/durable-execution-sdk-js';
 
 class User {
-  id: string = '';
   name: string = '';
+  email: string = '';
   createdAt: Date = new Date();
+  updatedAt: Date = new Date();
 }
 
 const result = await context.step(

--- a/aws-lambda-durable-functions-power/steering/advanced-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/advanced-patterns.md
@@ -255,7 +255,14 @@ class User {
 
 const result = await context.step(
   'create-user',
-  async () => new User('Alice', 'alice@example.com', new Date(), new Date()),
+  async () => {
+    const user = new User();
+    user.name = 'Alice';
+    user.email = 'alice@example.com';
+    user.createdAt = new Date();
+    user.updatedAt = new Date();
+    return user;
+  },
   {
     serdes: createClassSerdesWithDates(User, ['createdAt', 'updatedAt'])
   }
@@ -296,12 +303,23 @@ const customerSerdes = createClassSerdes(Customer);
 const result = await context.step(
   'process-order',
   async () => {
-    const customer = new Customer('CUST-123', 'Alice');
-    const items = [
-      new OrderItem('SKU-001', 2),
-      new OrderItem('SKU-002', 1)
-    ];
-    return new Order('ORD-456', items, customer);
+    const customer = new Customer();
+    customer.id = 'CUST-123';
+    customer.name = 'Alice';
+
+    const item1 = new OrderItem();
+    item1.sku = 'SKU-001';
+    item1.quantity = 2;
+
+    const item2 = new OrderItem();
+    item2.sku = 'SKU-002';
+    item2.quantity = 1;
+
+    const order = new Order();
+    order.id = 'ORD-456';
+    order.items = [item1, item2];
+    order.customer = customer;
+    return order;
   },
   { serdes: orderSerdes }
 );

--- a/aws-lambda-durable-functions-power/steering/advanced-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/advanced-patterns.md
@@ -247,12 +247,9 @@ import {
 } from '@aws/durable-execution-sdk-js';
 
 class User {
-  constructor(
-    public name: string,
-    public email: string,
-    public createdAt: Date,
-    public updatedAt: Date
-  ) {}
+  id: string = '';
+  name: string = '';
+  createdAt: Date = new Date();
 }
 
 const result = await context.step(
@@ -275,19 +272,19 @@ console.log(result.createdAt instanceof Date); // true
 import { createClassSerdes } from '@aws/durable-execution-sdk-js';
 
 class Order {
-  constructor(
-    public id: string,
-    public items: OrderItem[],
-    public customer: Customer
-  ) {}
+  id: string = '';
+  items: OrderItem[] = [];
+  customer: Customer = new Customer();
 }
 
 class OrderItem {
-  constructor(public sku: string, public quantity: number) {}
+  sku: string = '';
+  quantity: number = 0;
 }
 
 class Customer {
-  constructor(public id: string, public name: string) {}
+  id: string = '';
+  name: string = '';
 }
 
 // Create serdes for each class

--- a/aws-lambda-durable-functions-power/steering/step-operations.md
+++ b/aws-lambda-durable-functions-power/steering/step-operations.md
@@ -236,7 +236,13 @@ const userSerdes = createClassSerdesWithDates(User, ['createdAt']);
 
 const user = await context.step(
   'fetch-user',
-  async () => new User('123', 'Alice', new Date()),
+  async () => {
+    const user = new User();
+    user.id = '123';
+    user.name = 'Alice';
+    user.createdAt = new Date();
+    return user;
+  },
   { serdes: userSerdes }
 );
 ```


### PR DESCRIPTION
# Issue

The createClassSerdes and createClassSerdesWithDates function requires a no-argument constructor (new () => T) as defined in the [SDK type signature](https://github.com/aws/aws-durable-execution-sdk-js/blob/88b945b16eaf5f3ac670302407a4de66d4af1df3/packages/aws-durable-execution-sdk-js/src/utils/serdes/serdes.ts#L108):

```
export declare function createClassSerdesWithDates<T extends object>(
  cls: new () => T,  // zero-argument constructor required
  dateProps: string[]
): Serdes<T>;

```

The JSDoc also explicitly states: "The class constructor (must have no required parameters)"

The current example uses a constructor with 3 required parameters, which causes a TypeScript compile error:
```
Argument of type 'typeof User' is not assignable to parameter of type 'new () => User'.
Target signature provides too few arguments. Expected 3 or more, but got 0.
```


### Description of changes:

Updated createClassSerdesWithDates and createClassSerdesWithDates example to use no-arg constructor.