### PR TITLE
docs(power): use class references instead of strings in retryableErrorTypes examples

### DIFF
--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -121,7 +121,7 @@ const result = await context.step(
   {
     retryStrategy: createRetryStrategy({
       maxAttempts: 3,
-      retryableErrorTypes: ['NetworkError', 'TimeoutError'],
+      retryableErrorTypes: [NetworkError, TimeoutError],
       // ValidationError won't be retried
     })
   }

--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -121,7 +121,7 @@ const result = await context.step(
   {
     retryStrategy: createRetryStrategy({
       maxAttempts: 3,
-      retryableErrorTypes: [ValidationError, NetworkError],
+      retryableErrorTypes: [NetworkError, ValidationError],
       // ValidationError won't be retried
     })
   }

--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -121,7 +121,7 @@ const result = await context.step(
   {
     retryStrategy: createRetryStrategy({
       maxAttempts: 3,
-      retryableErrorTypes: [NetworkError, TimeoutError],
+      retryableErrorTypes: [ValidationError, NetworkError],
       // ValidationError won't be retried
     })
   }

--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -121,7 +121,7 @@ const result = await context.step(
   {
     retryStrategy: createRetryStrategy({
       maxAttempts: 3,
-      retryableErrorTypes: [NetworkError, ValidationError],
+      retryableErrorTypes: [NetworkError],
       // ValidationError won't be retried
     })
   }

--- a/aws-lambda-durable-functions-power/steering/step-operations.md
+++ b/aws-lambda-durable-functions-power/steering/step-operations.md
@@ -155,13 +155,21 @@ result = context.step(
 **TypeScript:**
 
 ```typescript
+class NetworkError extends Error {
+  name = 'NetworkError';
+}
+
+class TimeoutError extends Error {
+  name = 'TimeoutError';
+}
+
 const result = await context.step(
   'selective-retry',
   async () => operation(),
   {
     retryStrategy: createRetryStrategy({
       maxAttempts: 3,
-      retryableErrorTypes: ['NetworkError', 'TimeoutError']
+      retryableErrorTypes: [NetworkError, TimeoutError]
     })
   }
 );


### PR DESCRIPTION
# Issue

The retryableErrorTypes examples in error-handling.md and step-operations.md  pass string literals instead of class references:

retryableErrorTypes: ['NetworkError', 'TimeoutError']  // ❌ broken

The [SDK type signature is retryableErrorTypes?: (new () => Error)[]](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/utils/retry/retry-config/index.ts#L106) which requires class constructors, not strings. Passing strings causes a TypeScript compile error:
```
  Type 'string' is not assignable to type 'new () => Error'
```

# Description of changes:

Replace string literals with class references

retryableErrorTypes: [NetworkError, TimeoutError]  // ✅ correct

