### PR TITLE
docs(power): "When to use each" table has AtMostOncePerRetry and AtLeastOncePerRetry use cases swapped

### DIFF
--- a/aws-lambda-durable-functions-power/steering/advanced-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/advanced-patterns.md
@@ -134,8 +134,8 @@ await context.step(
 
 | Semantic                | Use When                      | Example Operations                                |
 | ----------------------- | ----------------------------- | ------------------------------------------------- |
-| **AtLeastOncePerRetry** | Operation is idempotent       | Database updates, API calls with idempotency keys |
-| **AtMostOncePerRetry**  | External deduplication exists | Queuing systems, event streams                    |
+| **AtLeastOncePerRetry** (default) | Operation is idempotent, or external dedup exists | Database upserts, idempotency-keyed API calls, queuing systems |
+| **AtMostOncePerRetry**            | Operation is non-idempotent, duplicates must be avoided | Charge payment, send unique notification, non-idempotent external writes |
 
 ## Completion Policies - Interaction and Combination
 

--- a/aws-lambda-durable-functions-power/steering/advanced-patterns.md
+++ b/aws-lambda-durable-functions-power/steering/advanced-patterns.md
@@ -134,8 +134,8 @@ await context.step(
 
 | Semantic                | Use When                      | Example Operations                                |
 | ----------------------- | ----------------------------- | ------------------------------------------------- |
-| **AtMostOncePerRetry**  | Operation is idempotent       | Database updates, API calls with idempotency keys |
-| **AtLeastOncePerRetry** | External deduplication exists | Queuing systems, event streams                    |
+| **AtLeastOncePerRetry** | Operation is idempotent       | Database updates, API calls with idempotency keys |
+| **AtMostOncePerRetry**  | External deduplication exists | Queuing systems, event streams                    |
 
 ## Completion Policies - Interaction and Combination
 


### PR DESCRIPTION
## Problem

The "When to use each" table in `advanced-patterns.md` has the use cases completely reversed:

**Current (wrong):**

| Semantic | Use When | Example Operations |
|---|---|---|
| **AtMostOncePerRetry** | Operation is idempotent | Database updates, API calls with idempotency keys |
| **AtLeastOncePerRetry** | External deduplication exists | Queuing systems, event streams |

## Why This Is Wrong

`AtMostOncePerRetry` is designed for **non-idempotent** operations. The SDK waits for the START checkpoint before executing, so if Lambda crashes mid-step, the step is skipped on replay rather than re-executed.

`AtLeastOncePerRetry` is designed for **idempotent** operations.

## Source

The SDK's own JSDoc in [`src/types/step.ts`](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/types/step.ts) confirms:

```typescript
// At-least-once per retry (default) - safe for idempotent operations
{ semantics: StepSemantics.AtLeastOncePerRetry }

// At-most-once per retry - for non-idempotent operations
{ semantics: StepSemantics.AtMostOncePerRetry }
