### PR TITLE
docs(power): step-operations.md uses incorrect string literals for step semantics instead of StepSemantics enum

### DIFF
--- a/aws-lambda-durable-functions-power/steering/step-operations.md
+++ b/aws-lambda-durable-functions-power/steering/step-operations.md
@@ -185,10 +185,12 @@ Step executes at least once, may execute multiple times on failure/retry.
 **TypeScript:**
 
 ```typescript
+import { StepSemantics } from '@aws/durable-execution-sdk-js';
+
 const result = await context.step(
   'idempotent-operation',
   async () => idempotentAPI(),
-  { semantics: 'AT_LEAST_ONCE' }
+  { semantics: StepSemantics.AtLeastOncePerRetry }
 );
 ```
 
@@ -199,10 +201,12 @@ Step executes at most once, never retries. Use for non-idempotent operations.
 **TypeScript:**
 
 ```typescript
+import { StepSemantics } from '@aws/durable-execution-sdk-js';
+
 const result = await context.step(
   'charge-payment',
   async () => chargeCard(amount),
-  { semantics: 'AT_MOST_ONCE' }
+  { semantics: StepSemantics.AtMostOncePerRetry }
 );
 ```
 


### PR DESCRIPTION
# issue

step-operations.md uses incorrect string literals for step semantics instead of StepSemantics enum

```typescript
// Wrong
{ semantics: 'AT_LEAST_ONCE' }
{ semantics: 'AT_MOST_ONCE' }
```

*Description of changes:*
```
import { StepSemantics } from '@aws/durable-execution-sdk-js';

// Correct
{ semantics: StepSemantics.AtLeastOncePerRetry }
{ semantics: StepSemantics.AtMostOncePerRetry }

```