### PR TITLE
docs(power): concurrent-operations.md calls succeeded and failed as properties but they are methods

### DIFF
--- a/aws-lambda-durable-functions-power/steering/concurrent-operations.md
+++ b/aws-lambda-durable-functions-power/steering/concurrent-operations.md
@@ -213,10 +213,10 @@ console.log(results.hasFailure);     // Boolean
 const allResults = results.getResults();
 
 // Get successful results only
-const successful = results.succeeded.map(item => item.result);
+const successful = results.succeeded().map(item => item.result);
 
 // Get failed items
-const failed = results.failed.map(item => ({
+const failed = results.failed().map(item => ({
   index: item.index,
   error: item.error
 }));
@@ -240,11 +240,11 @@ const results = await context.map('process', items, processFunc);
 if (results.hasFailure) {
   context.logger.error('Some items failed', {
     failureCount: results.failureCount,
-    failures: results.failed.map(f => f.index)
+    failures: results.failed().map(f => f.index)
   });
   
   // Retry failed items
-  const failedItems = results.failed.map(f => items[f.index]);
+  const failedItems = results.failed().map(f => items[f.index]);
   await context.map('retry-failed', failedItems, processFunc);
 }
 ```


### PR DESCRIPTION
# Issue

The "Get Results" section in `concurrent-operations.md` accesses `succeeded` and `failed` as properties:

```typescript
// As shown in docs — causes TypeScript error
const successful = results.succeeded.map(item => item.result);
const failed = results.failed.map(item => ({
  index: item.index,
  error: item.error
}));
```

This causes a TypeScript compile error:
```
Property 'map' does not exist on type '() => (BatchItem<number> & { result: number; })[]'
```

### Root Cause
succeeded and failed are [methods in the SDK](https://github.com/aws/aws-durable-execution-sdk-js/blob/main/packages/aws-durable-execution-sdk-js/src/handlers/concurrent-execution-handler/batch-result.ts#L18), not properties:

<img width="960" height="186" alt="image" src="https://github.com/user-attachments/assets/dadbe069-8f5f-4250-831f-b92fab88b141" />


### Description of changes:

Add parentheses to call them as methods.
