### PR TITLE
docs: expand authoring guide with writing style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,31 @@ python -m venv ~/.venvs/zensical
 source ~/.venvs/zensical/bin/activate
 pip install zensical
 ```
-### Preview site locally
-Once installed, activate the venv and run Zensical from the repository root:
+### Running Zensical
+
+Once installed, either activate the venv or run the binary directly:
 
 ```bash
+# Option 1: Activate the venv
 source ~/.venvs/zensical/bin/activate
-
-# Live preview with hot-reload
 zensical serve
 
-# Production build
-zensical build --clean
+# Option 2: Run directly without activating
+~/.venvs/zensical/bin/zensical serve
 ```
+
+Common commands:
+
+- `zensical serve` — live preview with hot-reload
+- `zensical build --clean` — production build
+- Review build output for broken link warnings
+
+### Adding New Pages
+
+1. Create the markdown file in `docs/`
+2. Add the page to the nav section in `zensical.toml`
+3. Create corresponding code examples in all three languages under `examples/`
+4. Test locally with `zensical serve`
 
 ## Vendored dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# AWS Lambda durable functions developer documentation source
+# AWS Lambda durable execution developer documentation source
 
 This repository contains the source for the AWS Lambda Durable Execution SDK
-documentation website at https://docs.aws.amazon.com/durable-execution,
-providing comprehensive guides and references for building resilient,
+documentation website at https://docs.aws.amazon.com/durable-execution, providing comprehensive guides and references for building resilient,
 long-running applications with AWS Lambda durable functions across
 multiple programming languages.
 
@@ -40,10 +39,9 @@ pip install zensical
 zensical serve
 ```
 
-For the full authoring workflow — adding code samples, formatting conventions,
-commit messages, and pull request process — see
-[CONTRIBUTING.md](CONTRIBUTING.md). For Markdown formatting syntax, please see
-the [Authoring Guide](authoring-guide.md).
+For the full authoring workflow, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+For writing style and Markdown formatting syntax, please see the [Authoring Guide](authoring-guide.md).
 
 ## Kiro Power
 
@@ -64,6 +62,7 @@ for details.
 - [AWS Lambda durable functions Documentation](https://docs.aws.amazon.com/lambda/latest/dg/durable-functions.html)
 - [JavaScript SDK Repository](https://github.com/aws/aws-durable-execution-sdk-js)
 - [Python SDK Repository](https://github.com/aws/aws-durable-execution-sdk-python)
+- [Java SDK Repository](https://github.com/aws/aws-durable-execution-sdk-java)
 
 ## Feedback & Support
 

--- a/authoring-guide.md
+++ b/authoring-guide.md
@@ -1,257 +1,426 @@
+# Authoring Guide
 
-# Getting started
+This guide covers how to author documentation for AWS Lambda Durable Functions.
+For setup and contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-For full documentation visit [zensical.org](https://zensical.org/docs/).
+Each SDK reference page must be equally useful to TypeScript, Python, and Java
+developers. No language is the implicit default. Language-specific quirks
+belong inside the relevant tab, not in shared prose.
 
-## Commands
-* [`zensical serve`][serve] - Start local web server
-* [`zensical build`][build] - Build your site
+## Verify Against SDK Source
 
-  [serve]: https://zensical.org/docs/usage/preview/
-  [build]: https://zensical.org/docs/usage/build/
+Before writing or updating any copy or examples, read the actual SDK source
+for every language. Do not trust existing docs. Do not guess. Verify every
+argument name, type, and return type against the source.
 
-## Example formatting
+Verify means: check each argument, each type of each argument and return,
+find the definition for each of those types, and if those types reference
+sub-types, find those too. Recurse until you have the full picture.
 
-### Admonitions
+For each code example:
 
-> Go to [documentation](https://zensical.org/docs/authoring/admonitions/)
+1. Find the method definition in the SDK source, not tests or docs
+2. For each parameter, find its type definition. Recurse through nested types.
+3. For Java, check both the sync and async variants (e.g. `step()` and `stepAsync()`)
+4. Check the testing libraries of each repo for examples to verify your example code actually works
 
-!!! note
+### SDK repositories
 
-    This is a **note** admonition. Use it to provide helpful information.
+You will need the SDK source for all three languages. Clone them alongside
+the docs repo:
 
-!!! warning
+| Repository | Source path to read |
+|---|---|
+| [aws-durable-execution-sdk-js](https://github.com/aws/aws-durable-execution-sdk-js) | `packages/aws-durable-execution-sdk-js/src` |
+| [aws-durable-execution-sdk-python](https://github.com/aws/aws-durable-execution-sdk-python) | `src/aws_durable_execution_sdk_python` |
+| [aws-durable-execution-sdk-java](https://github.com/aws/aws-durable-execution-sdk-java) | `sdk/src/main/java/software/amazon/lambda/durable` |
 
-    This is a **warning** admonition. Be careful!
+Testing SDKs are useful for confirming example code compiles and runs. The
+JavaScript and Java testing SDKs live in the same repos as the main SDKs
+(under `-testing` package paths). The Python testing SDK lives in a separate
+repo:
 
-### Details
+| Repository | Source path to read |
+|---|---|
+| [aws-durable-execution-sdk-python-testing](https://github.com/aws/aws-durable-execution-sdk-python-testing) | `src/aws_durable_execution_sdk_python_testing` |
 
-> Go to [documentation](https://zensical.org/docs/authoring/admonitions/#collapsible-blocks)
 
-??? info "Click to expand for more info"
-    
-    This content is hidden until you click to expand it.
-    Great for FAQs or long explanations.
+### Key source files
 
-## Code Blocks
+- **TypeScript**: `types/durable-context.ts` for `DurableContext`. Check
+  `types/step.ts`, `types/core.ts`, etc. for referenced types.
+- **Python**: `context.py` for `DurableContext`. Check `config.py` for
+  `StepConfig` and `StepSemantics`. Check `types.py` for `StepContext`.
+- **Java**: `DurableContext.java` for the interface. Check
+  `config/StepConfig.java`, `StepContext.java`, `StepSemantics.java`.
 
-> Go to [documentation](https://zensical.org/docs/authoring/code-blocks/)
+## Writing Style
 
-``` python hl_lines="2" title="Code blocks"
-def greet(name):
-    print(f"Hello, {name}!") # (1)!
+### Voice and Tone
 
-greet("Python")
+Write for developers who want to learn how to use the SDK. Be direct and
+technical. Avoid marketing language ("powerful", "flexible", "seamless").
+
+Don't use unnecessary words. Keep sentences concise.
+
+Use active voice. Write "the SDK checkpoints the result" not "the result is
+checkpointed".
+
+Every sentence must earn its place. If a sentence restates what the code
+already shows, delete it.
+
+Per Strunk and White, use definite, specific, concrete language. Prefer
+the specific to the general, the definite to the vague, the concrete to
+the abstract. In practice, avoid 'to be' and 'to have' where you can use
+stronger verbs.
+
+### Sentence Structure
+
+Do not use emdash (—) or hyphen as a dash. If you feel tempted to use one,
+break it into two sentences or use a comma.
+
+Keep sentences short. One idea per sentence.
+
+### What to Avoid
+
+**Listicles.** Do not create Terminology, Key Features, Best Practices, or
+FAQ sections. These are convenient for LLMs but not for humans learning to
+code. If you feel tempted to write one, fold the content into prose:
+
+- New terms: introduce the term naturally in the prose where it first appears
+- "Key features": drop them (usually marketing), or fold the underlying
+  capability into the relevant section
+- Best practices: fold the guidance into the section where it applies. A
+  naming best practice belongs in the "Naming steps" section, not a generic
+  "Best Practices" list.
+- FAQ Q&As: each question is either (a) a concept that belongs in prose,
+  (b) a code example that belongs in a code section, or (c) something
+  already covered elsewhere that doesn't need repeating
+
+**Navigation artifacts.** Do not add Table of Contents, "Back to top" links,
+or "Back to X" links. Zensical generates navigation automatically.
+
+**Language-specific notes outside tabs.** Any note that applies to only one
+language belongs inside that language's tab, not in shared prose.
+
+### List Items
+
+Do not use emdash or hyphen to separate a list item heading from its
+description. Use bold or links instead:
+
+```markdown
+- **StepConfig** configures retry behavior and timeouts
+- [wait()](operations/wait.md) pauses execution for a duration
 ```
 
-1.  > Go to [documentation](https://zensical.org/docs/authoring/code-blocks/#code-annotations)
+## Revise, Don't Append
 
-    Code annotations allow to attach notes to lines of code.
+When you update a page, revise the whole section. A fresh reader should not
+have to reconcile an opening sentence with a later correction tacked on at
+the end.
 
-Code can also be highlighted inline: `#!python print("Hello, Python!")`.
+If your new content qualifies, corrects, or extends something earlier on the
+page, rewrite the earlier prose too. Don't leave stale sentences in place
+because they were there first.
 
-## Content tabs
+Signs you are appending instead of revising:
 
-> Go to [documentation](https://zensical.org/docs/authoring/content-tabs/)
+- A new sentence at the end of a paragraph that qualifies an earlier one
+- A "Note" or "Update" near the end of a section that contradicts the opening
+- Two adjacent paragraphs making overlapping points
+- A new code example below an older, now-redundant one
+
+When you spot one in your own edit, rewrite the section so the reader gets
+a single, coherent story.
+
+## Look Before You Write
+
+Before writing a new page or section, search the docs for the topic. If
+another page already covers it, add to that page instead of creating a
+parallel explanation. Readers should get one canonical answer, not two
+competing ones.
+
+If you find conflicting information on another page, fix both at once. Don't
+leave a contradiction for the next reader to sort out.
+
+This applies equally to new pages and to edits on existing pages. A new
+section on an existing page can duplicate content elsewhere just as easily
+as a whole new page can.
+
+## Language Neutrality
+
+Tab order is always: **TypeScript → Python → Java**.
+
+If a language has a quirk, note it inside that language's tab:
+
+```markdown
+=== "TypeScript"
+
+    Pass `undefined` as the name to omit it.
+
+    ```typescript
+    --8<-- "examples/typescript/operations/steps/basic-step.ts"
+    ```
 
 === "Python"
 
-    ``` python
-    print("Hello from Python!")
+    The `@durable_step` decorator uses the function name automatically.
+
+    ```python
+    --8<-- "examples/python/operations/steps/basic-step.py"
     ```
 
-=== "Rust"
+=== "Java"
 
-    ``` rs
-    println!("Hello from Rust!");
+    The name is always required. Pass `null` to omit it.
+
+    ```java
+    --8<-- "examples/java/operations/steps/basic-step.java"
+    ```
+```
+
+## Page Structure
+
+SDK reference pages follow this pattern:
+
+1. One or two short paragraphs explaining what the operation does and when
+   to use it
+2. A minimal walkthrough example (tabs, all three languages)
+3. Method signature section with per-language tabs
+4. Parameters listed after the tabs (shared where identical, inside tabs
+   where language-specific)
+5. Returns and Throws/Raises after parameters
+6. Sub-sections for config types (StepConfig, StepContext, SemanticsEnum)
+   each with per-language tabs
+7. Conceptual sub-sections as needed (naming, configuration, data passing,
+   nesting, concurrency)
+8. "See also" at the end
+
+### Exemplar pages
+
+Model tone and structure on these pages:
+
+- [`wait.md`](docs/sdk-reference/operations/wait.md): simple method
+- [`step.md`](docs/sdk-reference/operations/step.md): complex method with multiple types
+- [`wait-for-condition.md`](docs/sdk-reference/operations/wait-for-condition.md): complex method with multiple types
+
+### Template
+
+```markdown
+# {Operation Name}
+
+## {Concept heading — what it does}
+
+{One or two paragraphs. Language-neutral. No listicles.}
+
+{Simple walkthrough example with tabs}
+
+## Method signature
+
+### {method name}
+
+=== "TypeScript"
+    {signature}
+    **Parameters:**
+    - ...
+    **Returns:** ...
+    **Throws:** ...
+
+=== "Python"
+    {signature}
+    **Parameters:**
+    - ...
+    **Returns:** ...
+    **Raises:** ...
+
+=== "Java"
+    {sync and async signatures}
+    **Parameters:**
+    - ...
+    **Returns:** ...
+    **Throws:** ...
+
+### {ConfigType}
+
+{same pattern — interface/dataclass/builder per tab}
+
+### {ContextType}
+
+### {SemanticsEnum}
+
+## The {operation}'s function
+
+### Anonymous {operation} functions
+
+### Pass arguments to the {operation} function
+
+## Naming {operations}
+
+## Configuration
+
+## See also
+
+- [Related page](link)
+```
+
+## Code Examples
+
+### Requirements
+
+All code examples must:
+
+- Include all three languages (TypeScript, Python, Java)
+- Be functionally equivalent across languages
+- Include necessary imports
+- Be minimal. Show the concept, not a full application.
+- Avoid comments that restate what the code does
+- Be verified against the actual SDK source before committing
+
+### File Organization
+
+```
+examples/
+  typescript/{section}/{subsection}/{example-name}.ts
+  python/{section}/{subsection}/{example-name}.py
+  java/{section}/{subsection}/{example-name}.java
+```
+
+Use hyphens in filenames. All three languages must have the same set of files.
+
+### Embedding in Docs
+
+Use the `--8<--` snippet syntax with content tabs:
+
+```markdown
+=== "TypeScript"
+
+    ```typescript
+    --8<-- "examples/typescript/operations/steps/basic-step.ts"
     ```
 
-## Diagrams
+=== "Python"
 
-> Go to [documentation](https://zensical.org/docs/authoring/diagrams/)
+    ```python
+    --8<-- "examples/python/operations/steps/basic-step.py"
+    ```
 
-``` mermaid
+=== "Java"
+
+    ```java
+    --8<-- "examples/java/operations/steps/basic-step.java"
+    ```
+```
+
+### Method Signatures
+
+Show the actual callable signature, not pseudocode. Use real types from the
+SDK.
+
+For Java, show both sync and async variants:
+
+```markdown
+=== "Java"
+
+    ```java
+    // sync
+    <T> T step(String name, Class<T> resultType, Function<StepContext, T> func)
+    <T> T step(String name, Class<T> resultType, Function<StepContext, T> func, StepConfig config)
+
+    // async
+    <T> DurableFuture<T> stepAsync(String name, Class<T> resultType, Function<StepContext, T> func)
+    <T> DurableFuture<T> stepAsync(String name, Class<T> resultType, Function<StepContext, T> func, StepConfig config)
+    ```
+```
+
+For TypeScript, show both overloads if they exist (e.g. named and unnamed).
+
+## Formatting Reference
+
+This project uses [Zensical](https://zensical.org) to build the documentation
+site.
+
+### Admonitions
+
+```markdown
+!!! note
+
+    This is a note admonition.
+
+!!! warning
+
+    This is a warning admonition.
+```
+
+### Collapsible Blocks
+
+```markdown
+??? info "Click to expand"
+
+    Hidden content here.
+```
+
+### Code Blocks
+
+````markdown
+```python hl_lines="2" title="Example"
+def greet(name):
+    print(f"Hello, {name}!")
+```
+````
+
+Inline code with syntax highlighting: `` `#!python print("Hello")` ``
+
+### Content Tabs
+
+```markdown
+=== "TypeScript"
+
+    ```typescript
+    console.log("Hello");
+    ```
+
+=== "Python"
+
+    ```python
+    print("Hello")
+    ```
+```
+
+### Diagrams
+
+````markdown
+```mermaid
 graph LR
   A[Start] --> B{Error?};
-  B -->|Yes| C[Hmm...];
-  C --> D[Debug];
-  D --> B;
-  B ---->|No| E[Yay!];
-```
-
-## Footnotes
-
-> Go to [documentation](https://zensical.org/docs/authoring/footnotes/)
-
-Here's a sentence with a footnote.[^1]
-
-Hover it, to see a tooltip.
-
-[^1]: This is the footnote.
-
-
-## Formatting
-
-> Go to [documentation](https://zensical.org/docs/authoring/formatting/)
-
-- ==This was marked (highlight)==
-- ^^This was inserted (underline)^^
-- ~~This was deleted (strikethrough)~~
-- H~2~O
-- A^T^A
-- ++ctrl+alt+del++
-
-## Icons, Emojis
-
-> Go to [documentation](https://zensical.org/docs/authoring/icons-emojis/)
-
-* :sparkles: `:sparkles:`
-* :rocket: `:rocket:`
-* :tada: `:tada:`
-* :memo: `:memo:`
-* :eyes: `:eyes:`
-
-## Maths
-
-> Go to [documentation](https://zensical.org/docs/authoring/math/)
-
-$$
-\cos x=\sum_{k=0}^{\infty}\frac{(-1)^k}{(2k)!}x^{2k}
-$$
-
-!!! warning "Needs configuration"
-    Note that MathJax is included via a `script` tag on this page and is not
-    configured in the generated default configuration to avoid including it
-    in a pages that do not need it. See the documentation for details on how
-    to configure it on all your pages if they are more Maths-heavy than these
-    simple starter pages.
-
-<script id="MathJax-script" async src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
-<script>
-  window.MathJax = {
-    tex: {
-      inlineMath: [["\\(", "\\)"]],
-      displayMath: [["\\[", "\\]"]],
-      processEscapes: true,
-      processEnvironments: true
-    },
-    options: {
-      ignoreHtmlClass: ".*|",
-      processHtmlClass: "arithmatex"
-    }
-  };
-</script>
-
-## Task Lists
-
-> Go to [documentation](https://zensical.org/docs/authoring/lists/#using-task-lists)
-
-* [x] Install Zensical
-* [x] Configure `zensical.toml`
-* [x] Write amazing documentation
-* [ ] Deploy anywhere
-
-## Tooltips
-
-> Go to [documentation](https://zensical.org/docs/authoring/tooltips/)
-
-[Hover me][example]
-
-  [example]: https://example.com "I'm a tooltip!"
-
-
-# basic markdown guide
-# Markdown in 5min
-
-## Headers
-```
-# H1 Header
-## H2 Header
-### H3 Header
-#### H4 Header
-##### H5 Header
-###### H6 Header
-```
-
-## Text formatting
-```
-**bold text**
-*italic text*
-***bold and italic***
-~~strikethrough~~
-`inline code`
-```
-
-## Links and images
-```
-[Link text](https://example.com)
-[Link with title](https://example.com "Hover title")
-![Alt text](image.jpg)
-![Image with title](image.jpg "Image title")
-```
-
-## Lists
-```
-Unordered:
-- Item 1
-- Item 2
-  - Nested item
-
-Ordered:
-1. First item
-2. Second item
-3. Third item
-```
-
-## Blockquotes
-```
-> This is a blockquote
-> Multiple lines
->> Nested quote
-```
-
-## Code blocks
-````
-```javascript
-function hello() {
-  console.log("Hello, world!");
-}
+  B -->|Yes| C[Retry];
+  B -->|No| D[Done];
 ```
 ````
 
-## Tables
-```
-| Header 1 | Header 2 | Header 3 |
-|----------|----------|----------|
-| Row 1    | Data     | Data     |
-| Row 2    | Data     | Data     |
+### Tables
+
+```markdown
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| name | string | Step identifier |
+| config | StepConfig | Optional configuration |
 ```
 
-## Horizontal rule
-```
----
-or
-***
-or
-___
-```
+## Checklist Before Committing
 
-## Task lists
-```
-- [x] Completed task
-- [ ] Incomplete task
-- [ ] Another task
-```
-
-## Escaping characters
-```
-Use backslash to escape: \* \_ \# \`
-```
-
-## Line breaks
-```
-End a line with two spaces  
-to create a line break.
-
-Or use a blank line for a new paragraph.
-```
+- [ ] All prose is language-neutral (no Python-only concepts described as universal)
+- [ ] No Table of Contents, no "Back to top" links, no "Back to X" links
+- [ ] No Terminology, Key Features, Best Practices, or FAQ sections
+- [ ] Tab order is TypeScript → Python → Java everywhere
+- [ ] Language-specific notes are inside tabs, not outside
+- [ ] All three languages have example files for every `--8<--` reference
+- [ ] Every example verified against the actual SDK source
+- [ ] Java method signatures show both sync and async variants
+- [ ] TypeScript signatures show both overloads where they exist
+- [ ] No emdash, no hyphen-as-dash
+- [ ] No passive voice
+- [ ] Updates are revisions, not tacked-on additions
+- [ ] Topic is not already covered (or duplicated) on another page
+- [ ] No contradictions with other pages
+- [ ] Ran `~/.venvs/zensical/bin/mdformat docs/path/to/file.md` on the updated file
+- [ ] Previewed with `~/.venvs/zensical/bin/zensical serve`


### PR DESCRIPTION
*Description of changes:*

Previously authoring-guide.md was a Zensical formatting reference only. Expand it into a full authoring guide that covers both how to write well for this project and how to use Zensical features.

New content:

- Writing style rules (no emdash, no passive voice, no listicles, no marketing language)
- SDK source verification requirement for code examples, with repo links and key source files per language
- "Revise, Don't Append" rule to prevent stale or contradictory prose when editing existing pages
- "Look Before You Write" rule to prevent duplicated or conflicting coverage across pages
- Language neutrality rules (tab order, notes inside tabs)
- Page structure template with exemplar pages
- Pre-commit checklist

Update CONTRIBUTING.md with both ways to run Zensical (activate venv or run the binary directly), a common commands list, and an "Adding New Pages" workflow.

Update README.md to use "durable execution" consistently, add the Java SDK repo link, and simplify the authoring guide reference now that it covers writing style as well as formatting.

*Issue #, if available:*




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
