### PR TITLE
docs: fix TypeScript unrecoverable error example

### DIFF
--- a/aws-lambda-durable-functions-power/steering/error-handling.md
+++ b/aws-lambda-durable-functions-power/steering/error-handling.md
@@ -238,21 +238,26 @@ Mark errors as unrecoverable to stop execution immediately:
 
 **TypeScript:**
 
-```typescript
-import { UnrecoverableInvocationError } from '@aws/durable-execution-sdk-js';
+The TypeScript SDK does not currently export a public unrecoverable invocation error type. To stop retrying a step, throw a domain error and configure the step with a retry strategy that does not retry:
 
+```typescript
 export const handler = withDurableExecution(async (event, context: DurableContext) => {
-  const user = await context.step('fetch-user', async () => {
-    const user = await fetchUser(event.userId);
-    
-    if (!user) {
-      // Stop execution immediately - no retry
-      throw new UnrecoverableInvocationError('User not found');
-    }
-    
-    return user;
-  });
-  
+  const user = await context.step(
+    'fetch-user',
+    async () => {
+      const user = await fetchUser(event.userId);
+
+      if (!user) {
+        throw new Error('User not found');
+      }
+
+      return user;
+    },
+    {
+      retryStrategy: () => ({ shouldRetry: false }),
+    },
+  );
+
   // Continue processing...
 });
 ```


### PR DESCRIPTION
## Summary
- Removes the TypeScript example that imports `UnrecoverableInvocationError`, which is not exported by the TypeScript SDK.
- Replaces it with the public `retryStrategy: () => ({ shouldRetry: false })` pattern for non-retryable step failures.

Fixes #173.

## Value
Prevents readers from copying a TypeScript example that fails to compile and points them to a supported SDK pattern instead.

## Validation
- Confirmed `UnrecoverableInvocationError` is not exported from the TypeScript SDK `index.ts` on `main`.
- Verified the updated document no longer contains `UnrecoverableInvocationError` and includes the no-retry `retryStrategy` example.

## Documentation
- Updated `aws-lambda-durable-functions-power/steering/error-handling.md`.

## Checks not run
- Documentation-only change; no local docs build was run in this sandbox.

## Limitations or follow-up
- A dedicated public TypeScript unrecoverable-error API remains tracked separately in the SDK feature request linked from the issue.