### PR TITLE
docs(operations): document nesting type observability trade-offs

### DIFF
--- a/docs/sdk-reference/operations/map.md
+++ b/docs/sdk-reference/operations/map.md
@@ -168,8 +168,14 @@ Use map to apply the same operation to every item in a collection. Use
     - `completionConfig` (optional) When to stop. Default: wait for all items.
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual item results.
-    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. `FLAT`
-        reduces operation overhead by ~30% at the cost of lower observability.
+    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`.
+        - With `NESTED`, child operations appear as separate scopes in the execution history,
+      making workflows easier to inspect and troubleshoot. This is recommended when
+      detailed execution visibility is important.
+        - With `FLAT`, child operations are flattened into the parent operation. This reduces
+      operation overhead by ~30%, but provides less detail in execution history and
+      observability tools such as CloudWatch logs. This is recommended for high-volume
+      workloads where minimizing overhead is more important than detailed tracing.
 
 === "Python"
 

--- a/docs/sdk-reference/operations/map.md
+++ b/docs/sdk-reference/operations/map.md
@@ -169,13 +169,9 @@ Use map to apply the same operation to every item in a collection. Use
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual item results.
     - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`.
-        - With `NESTED`, child operations appear as separate scopes in the execution history,
-      making workflows easier to inspect and troubleshoot. This is recommended when
-      detailed execution visibility is important.
-        - With `FLAT`, child operations are flattened into the parent operation. This reduces
-      operation overhead by ~30%, but provides less detail in execution history and
-      observability tools such as CloudWatch logs. This is recommended for high-volume
-      workloads where minimizing overhead is more important than detailed tracing.
+        This option is available only in the TypeScript SDK.
+        - With `NESTED`, the map operation wraps each iteration in its own child context with its own `CONTEXT` operation, so every iteration appears as a separate operation in the execution history. Use `NESTED` when you want to inspect each iteration's operations independently.
+        - With `FLAT`, the map operation uses a virtual context for each iteration and skips the per-iteration `CONTEXT` operation, so iterations no longer appear as separate operations in the execution history. This provides up to 2x cost reduction and up to 2x more iterations per execution. Use `FLAT` for high-volume workloads where per-iteration visibility matters less than operation overhead.
 
 === "Python"
 

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -174,8 +174,14 @@ execute the same operation concurrently for each item in a collection.
     - `completionConfig` (optional) When to stop. Default: wait for all branches.
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual branch results.
-    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. `FLAT`
-        reduces operation overhead by ~30% at the cost of lower observability.
+    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`.
+        - With `NESTED`, child operations appear as separate scopes in the execution history,
+      making workflows easier to inspect and troubleshoot. This is recommended when
+      detailed execution visibility is important.
+        - With `FLAT`, child operations are flattened into the parent operation. This reduces
+      operation overhead by ~30%, but provides less detail in execution history and
+      observability tools such as CloudWatch logs. This is recommended for high-volume
+      workloads where minimizing overhead is more important than detailed tracing.
 
 === "Python"
 

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -175,13 +175,9 @@ execute the same operation concurrently for each item in a collection.
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual branch results.
     - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`.
-        - With `NESTED`, child operations appear as separate scopes in the execution history,
-      making workflows easier to inspect and troubleshoot. This is recommended when
-      detailed execution visibility is important.
-        - With `FLAT`, child operations are flattened into the parent operation. This reduces
-      operation overhead by ~30%, but provides less detail in execution history and
-      observability tools such as CloudWatch logs. This is recommended for high-volume
-      workloads where minimizing overhead is more important than detailed tracing.
+        This option is available only in the TypeScript SDK.
+        - With `NESTED`, the parallel operation wraps each branch in its own child context with its own `CONTEXT` operation, so every branch appears as a separate operation in the execution history. Use `NESTED` when you want to inspect each branch's operations independently.
+        - With `FLAT`, the parallel operation uses a virtual context for each branch and skips the per-branch `CONTEXT` operation, so branches no longer appear as separate operations in the execution history. This provides up to 2x cost reduction and up to 2x more branches per execution. Use `FLAT` for high-volume workloads where per-branch visibility matters less than operation overhead.
 
 === "Python"
 


### PR DESCRIPTION
Fixes #188


Added documentation for `NestingType.NESTED` and `NestingType.FLAT` in both `parallel.md` and `map.md`.

Changes:
- Explain how `NESTED` preserves child operations as separate scopes in execution history
- Explain how `FLAT` reduces overhead by flattening child operations into the parent operation
- Document the observability trade-offs between the two modes
- Add guidance on when each option may be preferred

