### PR TITLE
docs(tests): callback results are JSON strings and must be parsed before comparison

### DIFF
--- a/examples/typescript/testing/assertions/assert-callback.ts
+++ b/examples/typescript/testing/assertions/assert-callback.ts
@@ -28,7 +28,7 @@ it("completes a callback from the test", async () => {
 
   const callback = runner.getOperation("approval");
   await callback.waitForData(WaitingOperationStatus.SUBMITTED);
-  await callback.sendCallbackSuccess(JSON.stringify("approved"));
+  await callback.sendCallbackSuccess("approved");
 
   const result = await runPromise;
 

--- a/examples/typescript/testing/assertions/assert-callback.ts
+++ b/examples/typescript/testing/assertions/assert-callback.ts
@@ -28,10 +28,12 @@ it("completes a callback from the test", async () => {
 
   const callback = runner.getOperation("approval");
   await callback.waitForData(WaitingOperationStatus.SUBMITTED);
-  await callback.sendCallbackSuccess("approved");
+  await callback.sendCallbackSuccess(JSON.stringify({ approved: true }));
 
   const result = await runPromise;
 
   expect(result.getStatus()).toBe(ExecutionStatus.SUCCEEDED);
-  expect(result.getResult()).toBe("approved");
+  
+  const { approved } = JSON.parse(result.getResult());
+  expect(approved).toBe(true);
 });


### PR DESCRIPTION
## Issue
Callback results are JSON strings and must be parsed before comparison:
<img width="855" height="366" alt="image" src="https://github.com/user-attachments/assets/73b78e4e-20b1-4f2d-bf84-435f5c3e4d5b" />


*Description of changes:*

Send proper JSON to callback and parse before comparison.
