### PR TITLE
docs(tests): Change return method for parallel example from getSucceeded to getResults

### DIFF
--- a/examples/typescript/testing/examples/parallel-workflow.ts
+++ b/examples/typescript/testing/examples/parallel-workflow.ts
@@ -8,7 +8,7 @@ const handler = withDurableExecution(async (event: unknown, context: DurableCont
     async (ctx) => await ctx.step("fetch-b", () => "data-b"),
     async (ctx) => await ctx.step("fetch-c", () => "data-c"),
   ]);
-  return results.getSucceeded();
+  return results.getResults();
 });
 
 let runner: LocalDurableTestRunner;


### PR DESCRIPTION
# Issue
results.getSucceeded() is not a valid method for the result of a parallel operation.

*Description of changes:*

Use results.getResults() instead.
