### PR TITLE
docs(tests): use get_results in Python parallel-workflow example

### DIFF
--- a/examples/python/testing/examples/parallel-workflow.py
+++ b/examples/python/testing/examples/parallel-workflow.py
@@ -29,7 +29,7 @@ def handler(event, context: DurableContext) -> list:
         ],
         name="fetch-all",
     )
-    return results.get_succeeded()
+    return results.get_results()
 
 
 def test_executes_branches_in_parallel():


### PR DESCRIPTION
# Issue
`results.get_succeeded()` is not a valid method on the Python `BatchResult`.
The Protocol in `types.py` only declares `get_results()`, and the concrete
class in `concurrency/models.py` exposes `succeeded()`, `get_results()`, and
`get_errors()` — no `get_succeeded`. The handler raises `AttributeError`,
the durable execution fails, and the test asserting
`InvocationStatus.SUCCEEDED` would fail.

Follow-up to #196, which fixed the same bug in the TypeScript sibling.

*Description of changes:*

Replace `results.get_succeeded()` with `results.get_results()` in
`examples/python/testing/examples/parallel-workflow.py`.