### PR TITLE
docs: Link to checkpoint consumption from operations

### DIFF
--- a/docs/getting-started/key-concepts.md
+++ b/docs/getting-started/key-concepts.md
@@ -98,6 +98,9 @@ Once the SDK persists a checkpoint, that operation's result is safe. If your fun
 interrupted at any point, the SDK can replay up to the last persisted checkpoint on the
 next invocation.
 
+For details on how durable operations consume checkpoints, see
+[Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).
+
 ## Replay
 
 Lambda keeps a running log of all durable operations as your function executes. When

--- a/docs/sdk-reference/operations/callback.md
+++ b/docs/sdk-reference/operations/callback.md
@@ -522,3 +522,9 @@ sam remote callback fail <callback-id> \
     waiting for the callback
 - [Wait](wait.md) Time-based durable waits.
 - [Error handling](../error-handling/retries.md)
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/child-context.md
+++ b/docs/sdk-reference/operations/child-context.md
@@ -322,3 +322,9 @@ them to verify the child context ran and produced the expected result.
 - [Steps](step.md) Run a single function with automatic checkpointing
 - [Parallel operations](parallel.md) Execute operations concurrently
 - [Map operations](map.md) Run operation for each item in a collection
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/invoke.md
+++ b/docs/sdk-reference/operations/invoke.md
@@ -274,3 +274,9 @@ Java exposes separate exception types for different failure modes:
 - [Child contexts](child-context.md) Group operations
 - [Parallel operations](parallel.md) Execute operations concurrently
 - [Map operations](map.md) Run operation for each item in a collection
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/map.md
+++ b/docs/sdk-reference/operations/map.md
@@ -688,3 +688,9 @@ operations. Each nested map creates its own set of child contexts.
 - [Child contexts](child-context.md) understand child context isolation
 - [Steps](step.md) use steps within map functions
 - [Error handling](../error-handling/errors.md) in durable functions
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -735,3 +735,9 @@ Each nested parallel creates its own set of child contexts.
 - [Child contexts](child-context.md) understand child context isolation
 - [Steps](step.md) use steps within parallel branches
 - [Error handling](../error-handling/errors.md) in durable functions
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/step.md
+++ b/docs/sdk-reference/operations/step.md
@@ -434,3 +434,9 @@ concurrent code path.
 - [Testing](../../testing/index.md)
 - [Wait operations](wait.md)
 - [Child contexts](child-context.md)
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/wait-for-condition.md
+++ b/docs/sdk-reference/operations/wait-for-condition.md
@@ -184,3 +184,9 @@ Lambda cold start time, and current system load.
 - [Callbacks](callback.md) - Wait for external system responses
 - [Steps](step.md) - Execute business logic with automatic checkpointing
 - [Getting Started](../../getting-started/index.md) - Learn the basics of durable functions
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).

--- a/docs/sdk-reference/operations/wait.md
+++ b/docs/sdk-reference/operations/wait.md
@@ -264,3 +264,9 @@ You can verify wait operations in your tests by inspecting the operations list:
 - [Wait for Condition](wait-for-condition.md) - Poll until a condition is met
 - [Callbacks](callback.md) - Wait for external system responses
 - [Getting Started](../../getting-started/index.md) - Learn the basics of durable functions
+
+!!! info "Checkpoint consumption"
+
+    Durable operations consume checkpoints. To understand how this operation affects
+    your checkpoint usage, see
+    [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption).


### PR DESCRIPTION
## Summary

Adds a link to the [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption) reference so readers can understand how each durable operation affects checkpoint usage.

- Adds an `git push -u origin docs/add-checkpoint-consumption-links 2>&1 | cat! info "Checkpoint consumption"` box to the end of each operation page: callback, child-context, invoke, map, parallel, step, wait, and wait-for-condition.
- Adds the same reference link to the end of the Checkpoints section in the Key Concepts page.

## Testing

Docs-only change. Verified Markdown/admonition syntax matches the existing MkDocs Material conventions used elsewhere in the operations docs.