### PR TITLE
docs(examples): await createCallback before destructuring in TypeScript serialization example

### DIFF
--- a/examples/typescript/sdk-reference/serialization/callback-config.ts
+++ b/examples/typescript/sdk-reference/serialization/callback-config.ts
@@ -18,7 +18,7 @@ const approvalSerdes: Omit<Serdes<ApprovalResult>, "serialize"> = {
 
 export const handler = withDurableExecution(
   async (event: unknown, context: DurableContext) => {
-    const [approval, callbackId] = context.createCallback("await-approval", {
+    const [approval, callbackId] = await context.createCallback("await-approval", {
       serdes: approvalSerdes,
     });
 


### PR DESCRIPTION
# Issue 

The TypeScript callback-serdes example embedded in `docs/sdk-reference/state/serialization.md` destructures the result of `context.createCallback()` without `await`:

​```ts
const [approval, callbackId] = context.createCallback("await-approval", {
  serdes: approvalSerdes,
});
​```

## Correct way:
[createCallback method signature](https://docs.aws.amazon.com/durable-execution/sdk-reference/operations/callback/#method-signatures)
<img width="1156" height="311" alt="image" src="https://github.com/user-attachments/assets/45fc5e31-d56e-457b-a84f-7a2a78948d0d" />

*Description of changes:*
* Used await before createCallback()