### PR TITLE
docs: fix wrong package name

### DIFF
--- a/examples/typescript/operations/invoke/invoke-with-config.ts
+++ b/examples/typescript/operations/invoke/invoke-with-config.ts
@@ -2,7 +2,7 @@ import {
   DurableContext,
   InvokeConfig,
   withDurableExecution,
-} from "@aws-durable-execution-sdk-js";
+} from "@aws/durable-execution-sdk-js";
 
 export const handler = withDurableExecution(
   async (event: { orderId: string }, context: DurableContext) => {


### PR DESCRIPTION
Fix import path for aws durable execution SDK