### PR TITLE
docs: refresh js exception hierarchy for v2

### DIFF
--- a/docs/sdk-reference/error-handling/errors.md
+++ b/docs/sdk-reference/error-handling/errors.md
@@ -58,10 +58,12 @@ error and the operation details.
       DOE[DurableOperationError]
       DOE --> StepError
       DOE --> CallbackError
-      DOE --> CallbackTimeoutError
-      DOE --> CallbackSubmitterError
+      CallbackError --> CallbackExternalError
+      CallbackError --> CallbackTimeoutError
+      CallbackError --> CallbackSubmitterError
       DOE --> InvokeError
       DOE --> ChildContextError
+      DOE --> PromiseCombinatorError
       DOE --> WaitForConditionError
       SIE["StepInterruptedError (retryStrategy callback only)"]
     ```
@@ -73,6 +75,18 @@ error and the operation details.
     `DurableOperationError` is the base class for all operation-level failures. Each
     subclass corresponds to a specific operation type. The `cause` property holds the
     original error your code threw.
+
+    `CallbackError` is the parent class for callback failures. `CallbackExternalError`
+    reports a failure the external entity sent through
+    `SendDurableExecutionCallbackFailure`. `CallbackTimeoutError` signals a callback
+    that exceeded its timeout. `CallbackSubmitterError` wraps a failure raised inside
+    the submitter function. The SDK throws `CallbackError` directly only for internal
+    callback failures that do not match a more specific subclass. Catch `CallbackError`
+    to handle every callback failure with a single branch.
+
+    `PromiseCombinatorError` wraps failures from the durable promise combinators
+    `context.promise.all`, `context.promise.allSettled`, `context.promise.any`, and
+    `context.promise.race`.
 
     The TypeScript SDK passes `StepInterruptedError` to your
     `retryStrategy(error, attempt)` callback when Lambda interrupts an at-most-once step

--- a/examples/typescript/sdk-reference/error-handling/exception-hierarchy.ts
+++ b/examples/typescript/sdk-reference/error-handling/exception-hierarchy.ts
@@ -2,22 +2,26 @@ import {
   DurableOperationError,
   StepError,
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
   CallbackSubmitterError,
   InvokeError,
   ChildContextError,
+  PromiseCombinatorError,
   WaitForConditionError,
   StepInterruptedError,
 } from "@aws/durable-execution-sdk-js";
 
 // DurableOperationError
-//   StepError:              step failed after retries exhausted
-//   CallbackError:          callback operation failed
-//   CallbackTimeoutError:   callback timed out
-//   CallbackSubmitterError: callback submitter failed
-//   InvokeError:            invoke operation failed
-//   ChildContextError:      child context failed
-//   WaitForConditionError:  wait-for-condition failed
+//   StepError:               step failed after retries exhausted
+//   CallbackError:           parent class for callback failures
+//     CallbackExternalError:   external entity reported failure
+//     CallbackTimeoutError:    callback timed out
+//     CallbackSubmitterError:  submitter function failed
+//   InvokeError:             invoke operation failed
+//   ChildContextError:       child context failed
+//   PromiseCombinatorError:  context.promise.{all,allSettled,any,race} failed
+//   WaitForConditionError:   wait-for-condition failed
 //
 // StepInterruptedError: internal sentinel. The SDK passes it to your
 //   retryStrategy(error, attempt) callback when Lambda interrupts an
@@ -28,10 +32,12 @@ export {
   DurableOperationError,
   StepError,
   CallbackError,
+  CallbackExternalError,
   CallbackTimeoutError,
   CallbackSubmitterError,
   InvokeError,
   ChildContextError,
+  PromiseCombinatorError,
   WaitForConditionError,
   StepInterruptedError,
 };


### PR DESCRIPTION
## Description

Refresh the TypeScript exception hierarchy diagram and example to reflect v2.0.0.

- Re-parent `CallbackTimeoutError` and `CallbackSubmitterError` under `CallbackError` in the TypeScript mermaid diagram.
- Add `CallbackExternalError` as a new `CallbackError` subclass (raised when the external entity reports a failure, for example through `SendDurableExecutionCallbackFailure`).
- Add `PromiseCombinatorError` as a new `DurableOperationError` sibling for `context.promise.all`, `allSettled`, `any`, and `race` failures.
- Update `examples/typescript/sdk-reference/error-handling/exception-hierarchy.ts` to import and export the new errors and reflect the graded callback hierarchy in its comment block.

Verified against `packages/aws-durable-execution-sdk-js/src/errors/durable-error/durable-error.ts` at `origin/main`. Python and Java diagrams in the same file are unaffected by these v2 changes.

`zensical build --clean` reports no issues. `mdformat` is idempotent on the changed file.

Closes #210