### PR TITLE
docs: add checkpoint-change hook examples for Python and Java

### DIFF
--- a/docs/sdk-reference/observability/plugins.md
+++ b/docs/sdk-reference/observability/plugins.md
@@ -141,11 +141,15 @@ snapshot of all operations.
 
 === "Python"
 
-    This hook is a work in progress and is not yet available in the Python SDK.
+    ```python
+    --8<-- "examples/python/sdk-reference/plugins/checkpoint-change-hook.py"
+    ```
 
 === "Java"
 
-    This hook is a work in progress and is not yet available in the Java SDK.
+    ```java
+    --8<-- "examples/java/sdk-reference/plugins/checkpoint-change-hook.java"
+    ```
 
 ## Use a plugin
 

--- a/examples/java/sdk-reference/plugins/checkpoint-change-hook.java
+++ b/examples/java/sdk-reference/plugins/checkpoint-change-hook.java
@@ -1,0 +1,4 @@
+@Override
+public void onOperationChange(OperationChangeInfo info) {
+    System.out.println("operations changed, ids: " + info.updatedOperations().keySet());
+}

--- a/examples/java/sdk-reference/plugins/complete-plugin.java
+++ b/examples/java/sdk-reference/plugins/complete-plugin.java
@@ -3,6 +3,7 @@ import software.amazon.lambda.durable.plugin.InvocationInfo;
 import software.amazon.lambda.durable.plugin.InvocationEndInfo;
 import software.amazon.lambda.durable.plugin.OperationInfo;
 import software.amazon.lambda.durable.plugin.OperationEndInfo;
+import software.amazon.lambda.durable.plugin.OperationChangeInfo;
 import software.amazon.lambda.durable.plugin.UserFunctionStartInfo;
 import software.amazon.lambda.durable.plugin.UserFunctionEndInfo;
 
@@ -27,6 +28,11 @@ public class ExamplePlugin implements DurableExecutionPlugin {
     @Override
     public void onOperationEnd(OperationEndInfo info) {
         System.out.println("operation " + info.name() + " end, error: " + info.error());
+    }
+
+    @Override
+    public void onOperationChange(OperationChangeInfo info) {
+        System.out.println("operations changed, ids: " + info.updatedOperations().keySet());
     }
 
     @Override

--- a/examples/python/sdk-reference/plugins/checkpoint-change-hook.py
+++ b/examples/python/sdk-reference/plugins/checkpoint-change-hook.py
@@ -1,0 +1,2 @@
+def on_operation_change(self, info: OperationChangeInfo) -> None:
+    print("operations changed", "ids:", list(info.updated_operations.keys()))

--- a/examples/python/sdk-reference/plugins/complete-plugin.py
+++ b/examples/python/sdk-reference/plugins/complete-plugin.py
@@ -4,6 +4,7 @@ from aws_durable_execution_sdk_python.plugin import (
     InvocationEndInfo,
     OperationStartInfo,
     OperationEndInfo,
+    OperationChangeInfo,
     UserFunctionStartInfo,
     UserFunctionEndInfo,
 )
@@ -21,6 +22,9 @@ class ExamplePlugin(DurableInstrumentationPlugin):
 
     def on_operation_end(self, info: OperationEndInfo) -> None:
         print(f"operation {info.name} end, status: {info.status}, error: {info.error}")
+
+    def on_operation_change(self, info: OperationChangeInfo) -> None:
+        print("operations changed", "ids:", list(info.updated_operations.keys()))
 
     def on_user_function_start(self, info: UserFunctionStartInfo) -> None:
         print(f"user function {info.name} start, attempt: {info.attempt}")

--- a/examples/typescript/sdk-reference/plugins/complete-plugin.ts
+++ b/examples/typescript/sdk-reference/plugins/complete-plugin.ts
@@ -27,6 +27,10 @@ export const examplePlugin: DurableInstrumentationPlugin = {
     console.log(`operation ${info.name} end, status: ${info.status}, error: ${info.error}`);
   },
 
+  async onOperationChange(info: OperationChangeInfo): Promise<void> {
+    console.log(`operations changed, ids: ${Object.keys(info.updatedOperations)}`);
+  },
+
   async onOperationAttemptStart(info: AttemptInfo): Promise<void> {
     console.log(`attempt ${info.name} start, attempt: ${info.attempt}`);
   },
@@ -51,10 +55,6 @@ export const examplePlugin: DurableInstrumentationPlugin = {
   wrapOperationAttemptFn(info: AttemptInfo, fn: () => unknown): unknown {
     console.log(`wrap attempt ${info.name}, attempt: ${info.attempt}`);
     return fn();
-  },
-
-  async onOperationChange(info: OperationChangeInfo): Promise<void> {
-    console.log(`operations changed, ids: ${Object.keys(info.updatedOperations)}`);
   },
 
   enrichLogContext(): Record<string, string | number | boolean> {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-durable-execution-docs/issues/219

*Description of changes:*

Checkpoint-change hooks have been implemented in the Java and Python SDKs.

This PR adds examples for those hooks to the plugins docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
