### PR TITLE
docs(testing&SDK): correct IAM resource ARN and add callback permissions pointer

### DIFF
--- a/docs/sdk-reference/operations/callback.md
+++ b/docs/sdk-reference/operations/callback.md
@@ -552,6 +552,8 @@ describes what the callback is waiting for.
 
 ## Send callback results
 
+The calling principal needs permission to send callbacks for the durable execution. See [Security and permissions for Lambda durable functions](https://docs.aws.amazon.com/lambda/latest/dg/durable-security.html) in the AWS Lambda Developer Guide.
+
 External systems send results back using the
 [`SendDurableExecutionCallbackSuccess`](https://docs.aws.amazon.com/lambda/latest/api/API_SendDurableExecutionCallbackSuccess.html)
 or

--- a/docs/testing/cloud-runner.md
+++ b/docs/testing/cloud-runner.md
@@ -105,7 +105,7 @@ The IAM principal running the tests needs these permissions on the target functi
     "lambda:GetDurableExecution",
     "lambda:GetDurableExecutionHistory"
   ],
-  "Resource": "arn:aws:lambda:region:account-id:function:function-name"
+  "Resource": "arn:aws:lambda:region:account-id:function:function-name:*"
 }
 ```
 


### PR DESCRIPTION
Fixes https://github.com/aws/aws-durable-execution-docs/issues/223

## Changes

1. Fix IAM resource ARN in  cloud-runner.md

The "Required IAM permissions" example used an unqualified function ARN as the Resource for all three actions.

2. Add permissions pointer in  callback.md

The "Send callback results" section had no mention of IAM permissions. A developer could follow the SDK docs correctly and still hit AccessDeniedException when their external system calls the callback APIs, with no hint about why.
Added one line at the top of the section pointing to the Security and permissions for Lambda durable functions page in the AWS Lambda Developer Guide.