### PR TITLE
docs: document DurableConfig ExecutionTimeout and RetentionPeriodInDays ranges (1-90)

### DIFF
--- a/docs/sdk-reference/configuration/index.md
+++ b/docs/sdk-reference/configuration/index.md
@@ -2,3 +2,30 @@
 
 - [Custom Lambda Client](custom-lambda-client.md) Configure the Lambda client used by
     the SDK
+
+## Durable execution configuration
+
+A durable function's behavior is controlled by its `DurableConfig`, which you set on
+the function resource at deploy time (not in your handler code). The `DurableConfig`
+holds two parameters:
+
+| Parameter                | Required | Valid range                            | Default    | Description                                                                              |
+| ------------------------ | -------- | -------------------------------------- | ---------- | ---------------------------------------------------------------------------------------- |
+| `ExecutionTimeout`       | Yes      | `1` to `31622400` seconds (up to ~1 year) | None       | Maximum wall-clock time a single durable execution may run across all of its invocations. |
+| `RetentionPeriodInDays`  | No       | `1` to `90` days                       | `14`       | How long the durable execution's history is retained after the execution completes.      |
+
+These bounds are enforced by the Lambda service; a value outside the valid range is
+rejected when you create or update the function.
+
+You set `DurableConfig` wherever you define the function. For example, with the AWS CLI:
+
+```bash
+aws lambda create-function \
+  --function-name my-durable-function \
+  # ... other options ... \
+  --durable-config '{"ExecutionTimeout": 900, "RetentionPeriodInDays": 7}'
+```
+
+The same parameters are available through CloudFormation/SAM (`DurableConfig` on the
+function), the AWS CDK (`retentionPeriod`), and the C# `[DurableExecution]` annotation
+(`RetentionPeriodInDays`).


### PR DESCRIPTION
## What

Adds a **Durable execution configuration** reference to the configuration section documenting the `DurableConfig` parameters and their service-enforced valid ranges:

| Parameter | Required | Valid range | Default |
| --- | --- | --- | --- |
| `ExecutionTimeout` | Yes | `1`–`31622400` seconds (366-day year) | None |
| `RetentionPeriodInDays` | No | `1`–`90` days | `14` |

## Why (addresses #23)

While verifying #23 I found the docs **never documented a range** for `RetentionPeriodInDays` — it only appeared as example values (`1` in the quickstarts, `7` in the C# example). So the specific "1-365 → 1-90" correction requested in #23 didn't apply to any existing text; the real gap was the missing reference. This PR closes that gap with the correct **1–90** range.

Ranges and the **default of 14 days** are sourced from the [AWS SAM `DurableConfig` reference](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-durableconfig.html) (`RetentionPeriodInDays`: min 1, max 90, default 14; `ExecutionTimeout`: min 1, max 31622400).

## Testing

Docs-only change. `zensical` is not installed in my environment, so I have not run a local site build — please confirm the table renders and no link warnings appear in CI.

Closes #23