### PR TITLE
ci: add PR quality checks (spelling, acronyms, hidden chars, markdown formatting)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,46 @@
+name: PR quality checks
+
+# Runs on every pull request so it can be marked as a required status check.
+# (No paths filter: a path-filtered required check that is skipped blocks merges.)
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: docs quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install quality tooling
+        run: pip install mdformat mdformat-mkdocs mdformat-gfm codespell
+
+      # 4. Markdown formatting. Config lives in [tool.mdformat] in pyproject.toml.
+      - name: Markdown formatting (mdformat)
+        run: mdformat --check docs/
+
+      # 1 & 2. Spelling and known acronyms. codespell reads [tool.codespell] from
+      # pyproject.toml (skip list + ignore-words-list of known acronyms/identifiers).
+      - name: Spelling and acronyms (codespell)
+        run: codespell docs/
+
+      # 3. Prevent hidden / invisible characters in hand-authored markdown:
+      # zero-width space/joiners (U+200B-U+200D), BOM/ZWNBSP (U+FEFF),
+      # line/paragraph separators (U+2028/U+2029), and non-breaking space (U+00A0).
+      - name: No hidden / invisible characters
+        run: |
+          matches=$(grep -rlP '[\x{200B}\x{200C}\x{200D}\x{FEFF}\x{2028}\x{2029}\x{00A0}]' docs --include='*.md' || true)
+          if [ -n "$matches" ]; then
+            echo "::error::Hidden or invisible Unicode characters found in:"
+            echo "$matches"
+            echo "Remove zero-width spaces, BOMs, non-breaking spaces, and line/paragraph separators."
+            exit 1
+          fi
+          echo "No hidden characters found."

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -22,4 +22,3 @@ flowchart LR
     style dev fill:#e3f2fd
     style prod fill:#fff3e0
 ```
-

--- a/docs/getting-started/key-concepts.md
+++ b/docs/getting-started/key-concepts.md
@@ -72,7 +72,7 @@ specific purpose:
     consuming compute resources
 - [Callbacks](../sdk-reference/operations/callback.md) Suspend execution and wait for an
     external system to submit a result
-- [Invoke](../sdk-reference/operations/invoke.md) Invoke another Lambda function, suspending 
+- [Invoke](../sdk-reference/operations/invoke.md) Invoke another Lambda function, suspending
     until we checkpoint the result
 - [Parallel](../sdk-reference/operations/parallel.md) Execute multiple independent
     operations concurrently
@@ -94,11 +94,11 @@ When your code calls a durable operation, the SDK follows this sequence:
 
 1. **Check for an existing checkpoint** if this operation already completed in a
     previous invocation, the SDK returns the stored result without re-executing
-2. **Execute the operation** if no checkpoint exists, the SDK runs the operation code
-3. **Serialize the result** the SDK serializes the result for storage
-4. **Persist the checkpoint** the SDK calls the Lambda checkpoint API to durably store
+1. **Execute the operation** if no checkpoint exists, the SDK runs the operation code
+1. **Serialize the result** the SDK serializes the result for storage
+1. **Persist the checkpoint** the SDK calls the Lambda checkpoint API to durably store
     the result before continuing
-5. **Return the result** execution continues to the next operation
+1. **Return the result** execution continues to the next operation
 
 Once the SDK persists a checkpoint, that operation's result is safe. If your function is
 interrupted at any point, the SDK can replay up to the last persisted checkpoint on the
@@ -116,11 +116,11 @@ again from the beginning and replays the checkpoint log:
 
 1. **Load checkpoint log** the SDK retrieves the checkpoint log for the execution from
     Lambda
-2. **Run from beginning** your handler runs from the start, not from where it paused
-3. **Skip completed operations** as your code calls durable operations, the SDK checks
+1. **Run from beginning** your handler runs from the start, not from where it paused
+1. **Skip completed operations** as your code calls durable operations, the SDK checks
     each against the checkpoint log and returns stored results without re-executing the
     operation code, saving you active lambda compute time costs
-4. **Resume at interruption point** when the SDK reaches an operation without a
+1. **Resume at interruption point** when the SDK reaches an operation without a
     checkpoint, it executes normally and creates new checkpoints from that point
     forward
 
@@ -150,10 +150,10 @@ Wrap such non-deterministic code in [steps](../sdk-reference/operations/step.md)
 ### Rules for deterministic durable operations
 
 1. All durable operations in a context must start sequentially.
-2. To run durable operations concurrently, wrap each set of operations in its own
+1. To run durable operations concurrently, wrap each set of operations in its own
     [child context](../sdk-reference/operations/child-context.md) and then run the
     child contexts concurrently.
-3. Only use the child `DurableContext` in the child context scope. Do not use any
+1. Only use the child `DurableContext` in the child context scope. Do not use any
     parent's context in a child context scope.
 
 ## Replay Walkthrough
@@ -187,35 +187,35 @@ Let's trace through a simple workflow:
 **First invocation (t=0s):**
 
 1. You start a durable execution by invoking a durable function
-2. The durable functions service invokes your durable function handler
-3. The fetch step runs and calls an external API
-4. The SDK checkpoints the result of the fetch step
-5. Execution reaches `context.wait()` and the SDK checkpoints the wait operation
-6. The SDK terminates the current Lambda invocation, but the durable execution is still
+1. The durable functions service invokes your durable function handler
+1. The fetch step runs and calls an external API
+1. The SDK checkpoints the result of the fetch step
+1. Execution reaches `context.wait()` and the SDK checkpoints the wait operation
+1. The SDK terminates the current Lambda invocation, but the durable execution is still
     active
 
 **Second invocation (t=30s):**
 
 1. The durable functions service invokes your function again
-2. The function runs from the beginning
-3. The fetch step returns its checkpointed result instantly, it does not re-execute the
+1. The function runs from the beginning
+1. The fetch step returns its checkpointed result instantly, it does not re-execute the
     API call
-4. The wait has already elapsed, so execution continues
-5. The process step runs for the first time
-6. The SDK checkpoints the result of the process step
-7. The function returns naturally and the invocation ends
-8. The durable execution ends
+1. The wait has already elapsed, so execution continues
+1. The process step runs for the first time
+1. The SDK checkpoints the result of the process step
+1. The function returns naturally and the invocation ends
+1. The durable execution ends
 
 ## Cost implications
 
 With durable functions, you pay for what you use. The pricing dimensions are (in no particular order):
 
 1. Lambda compute duration
-2. Lambda requests
-3. Durable operations
-4. Storage written
-5. Storage persisted
-6. Data transfer
+1. Lambda requests
+1. Durable operations
+1. Storage written
+1. Storage persisted
+1. Data transfer
 
 When your execution is suspended, you're not paying for compute. A small storage persisted charge keeps your checkpoints around while your execution is suspended and through the retention period after it completes. Operations are what make suspension possible, each one creates a checkpoint, and each checkpoint has its own cost. See [Checkpoint consumption](https://docs.aws.amazon.com/lambda/latest/dg/durable-execution-sdk.html#durable-operations-checkpoint-consumption) for the breakdown.
 

--- a/docs/sdk-reference/languages/java/index.md
+++ b/docs/sdk-reference/languages/java/index.md
@@ -133,15 +133,15 @@ The main changes are:
 
 - Replace `StepConfig.builder().semantics(...)` with `semanticsPerRetry(...)`.
 - Preserve old `AT_MOST_ONCE_PER_RETRY` behavior by also setting
-  `retryStrategy(RetryStrategies.Presets.NO_RETRY)`.
+    `retryStrategy(RetryStrategies.Presets.NO_RETRY)`.
 - Update log queries and dashboards from `durableExecutionArn`, `contextId`, and
-  `contextName` to `executionArn`, `operationId`, and `operationName`.
+    `contextName` to `executionArn`, `operationId`, and `operationName`.
 - Move replay checks to `DurableContext.isReplaying()`; `StepContext` no longer exposes
-  replay state.
+    replay state.
 - Update tests and error handling that expect invalid context usage to throw
-  `IllegalDurableOperationException`; `2.x` throws `IllegalStateException`.
+    `IllegalDurableOperationException`; `2.x` throws `IllegalStateException`.
 - Verify custom `SerDes` implementations can deserialize values immediately after
-  serialization. `2.x` validates this round trip before checkpointing by default.
+    serialization. `2.x` validates this round trip before checkpointing by default.
 
 Useful searches before upgrading:
 

--- a/docs/sdk-reference/operations/child-context.md
+++ b/docs/sdk-reference/operations/child-context.md
@@ -331,11 +331,11 @@ sequentially in the parent.
 ### Concurrency rules
 
 1. All durable operations inside a context must start sequentially.
-2. To run durable operations concurrently, enclose each set of operations in its own
+1. To run durable operations concurrently, enclose each set of operations in its own
     child context.
-3. Start each child context serially. You do not have to wait for the previous child
+1. Start each child context serially. You do not have to wait for the previous child
     context to complete before starting the next.
-4. Inside the child function you must use the child context argument, not the parent
+1. Inside the child function you must use the child context argument, not the parent
     context.
 
 === "TypeScript"

--- a/docs/sdk-reference/operations/invoke.md
+++ b/docs/sdk-reference/operations/invoke.md
@@ -43,7 +43,7 @@ sequenceDiagram
 ```
 
 - **Function** The durable Lambda function. This contains your code.
-- **Target Function** The Lambda function targetted by the durable invoke.
+- **Target Function** The Lambda function targeted by the durable invoke.
 - **Execution** The complete end-to-end lifecycle of a durable function, spanning
     potentially multiple invocations.
 - **Invocation** A single Lambda invocation within the execution. The invocation
@@ -82,12 +82,12 @@ When this function runs:
 
 1. The SDK checkpoints the first invoke operation's start and triggers
     `validate-order-function`
-2. The calling function suspends until the validation result is available
-3. The backend checkpoints the invoke's result and reinvokes the calling function
-4. Execution resumes with the validation result
-5. The SDK checkpoints the second invoke's start and triggers
+1. The calling function suspends until the validation result is available
+1. The backend checkpoints the invoke's result and reinvokes the calling function
+1. Execution resumes with the validation result
+1. The SDK checkpoints the second invoke's start and triggers
     `payment-processor-function`
-6. The calling function suspends again until the payment result is available
+1. The calling function suspends again until the payment result is available
 
 ## Method signature
 

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -776,14 +776,14 @@ ongoing work in abandoned branches, but cancellation is not guaranteed.
     parallel operation completed. Branches that were not dispatched before the operation
     resolved appear in `result.All` with status `Started`.
 
-    | `CompletionConfig`                 | Early exit `CompletionReason` | Full completion `CompletionReason` |
-    | ---------------------------------- | ----------------------------- | ---------------------------------- |
-    | `AllSuccessful()` (default)        | `FailureToleranceExceeded`    | `AllCompleted`                     |
-    | `AllCompleted()`                   | n/a                           | `AllCompleted`                     |
-    | `FirstSuccessful()`                | `MinSuccessfulReached`        | `AllCompleted`                     |
-    | `MinSuccessful = N`                | `MinSuccessfulReached`        | `AllCompleted`                     |
-    | `ToleratedFailureCount = N`        | `FailureToleranceExceeded`    | `AllCompleted`                     |
-    | `ToleratedFailurePercentage = N`   | `FailureToleranceExceeded`    | `AllCompleted`                     |
+    | `CompletionConfig`               | Early exit `CompletionReason` | Full completion `CompletionReason` |
+    | -------------------------------- | ----------------------------- | ---------------------------------- |
+    | `AllSuccessful()` (default)      | `FailureToleranceExceeded`    | `AllCompleted`                     |
+    | `AllCompleted()`                 | n/a                           | `AllCompleted`                     |
+    | `FirstSuccessful()`              | `MinSuccessfulReached`        | `AllCompleted`                     |
+    | `MinSuccessful = N`              | `MinSuccessfulReached`        | `AllCompleted`                     |
+    | `ToleratedFailureCount = N`      | `FailureToleranceExceeded`    | `AllCompleted`                     |
+    | `ToleratedFailurePercentage = N` | `FailureToleranceExceeded`    | `AllCompleted`                     |
 
     When the operation resolves with `FailureToleranceExceeded`, awaiting it throws
     `ParallelException`, which carries the aggregate result on `Result`.

--- a/docs/sdk-reference/operations/wait-for-condition.md
+++ b/docs/sdk-reference/operations/wait-for-condition.md
@@ -57,9 +57,9 @@ An attempt proceeds in this order:
 1. The SDK runs the check function with the current state. The first attempt receives
     the `initialState` you configured. Each later attempt receives the state the
     previous check returned.
-2. The SDK evaluates whether the condition is met. If it is, `waitForCondition`
+1. The SDK evaluates whether the condition is met. If it is, `waitForCondition`
     checkpoints the final state and returns it.
-3. If the condition is not met, the SDK checkpoints the delay for this attempt,
+1. If the condition is not met, the SDK checkpoints the delay for this attempt,
     suspends the function, and resumes for the next attempt once the delay elapses.
 
 Where you express the stop-or-continue decision differs by language. See

--- a/docs/testing/api-reference.md
+++ b/docs/testing/api-reference.md
@@ -1290,8 +1290,8 @@ The status of an individual operation.
     `OperationStatus` from `Amazon.Lambda.DurableExecution.Testing` is a static class of
     string constants (compare against `TestStep.Status`), not an enum:
 
-    | Constant                  | Meaning                          |
-    | ------------------------- | -------------------------------- |
+    | Constant                    | Meaning                          |
+    | --------------------------- | -------------------------------- |
     | `OperationStatus.Started`   | Operation is running             |
     | `OperationStatus.Succeeded` | Operation completed successfully |
     | `OperationStatus.Failed`    | Operation failed                 |
@@ -1334,8 +1334,8 @@ The status of an individual operation.
 
     `OperationKind` from `Amazon.Lambda.DurableExecution.Testing` (read via `TestStep.Kind`):
 
-    | Value                       | Meaning                      |
-    | --------------------------- | ---------------------------- |
+    | Value                         | Meaning                      |
+    | ----------------------------- | ---------------------------- |
     | `OperationKind.Step`          | A step operation             |
     | `OperationKind.Wait`          | A wait operation             |
     | `OperationKind.Callback`      | A callback operation         |

--- a/docs/testing/sam-cli.md
+++ b/docs/testing/sam-cli.md
@@ -3,7 +3,7 @@
 SAM CLI provides two ways to test durable functions:
 
 1. local invocation inside a local container.
-2. remote invocation against a deployed function.
+1. remote invocation against a deployed function.
 
 ## Local invoke
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,7 @@ number = true
 extensions = ["mkdocs", "tables"]
 
 [tool.codespell]
-skip = "*.lock"
+skip = "*.lock,docs/assets,*.min.js,*.tiny.js"
+# Known acronyms, code identifiers, and intentional spellings that are not typos.
+# Entries are lowercased. Add new false positives here rather than disabling the check.
+ignore-words-list = "sie,oce,afterall,re-use"


### PR DESCRIPTION
## What

Adds `.github/workflows/quality.yml`, a `pull_request`-triggered workflow implementing the four checks from #83:

| # | Check | Implementation |
| --- | --- | --- |
| 1 | Spelling | `codespell docs/` |
| 2 | Known acronyms | `codespell` `ignore-words-list` in `pyproject.toml` (`sie`, `oce`, `afterall`, `re-use`) |
| 3 | Hidden chars | grep for zero-width (U+200B–U+200D), BOM/ZWNBSP (U+FEFF), line/para separators (U+2028/U+2029), NBSP (U+00A0) in `docs/**/*.md` |
| 4 | Markdown formatting | `mdformat --check docs/` |

The tooling (`mdformat`, `mdformat-mkdocs`, `mdformat-gfm`, `codespell`) and its config were **already** declared in `pyproject.toml` (per @yaythomas's note on the issue) — there just wasn't a workflow running them on PRs. This wires them in.

## Making `main` green from day one

The checks are run against the whole `docs/` corpus, which had never been linted, so this PR also fixes the pre-existing violations:

- **codespell config**: skip vendored `docs/assets/` + minified JS (892 false hits in `mermaid.tiny.js`); add an `ignore-words-list` for known acronyms / code identifiers — `SIE`/`OCE` are Mermaid node IDs (StepInterruptedError / OperationCanceledException), `afterAll` is a test hook, `re-use` is intentional.
- **real typo fixed**: `targetted` → `targeted` (`invoke.md`).
- **reformatted 9 docs files** with `mdformat` (using the existing `[tool.mdformat]` config: `wrap=88`). Verified non-destructive — Mermaid fence counts and all 524 `--8<--` snippet-include directives are unchanged.

All three checks pass locally on this branch.

## Follow-up required to make it *blocking*

A workflow file can't set branch protection. To enforce the gate, a maintainer needs to add the **`docs quality checks`** job as a **required status check** on `main` in the repo's branch-protection settings. (The workflow runs on all PRs — no `paths` filter — precisely so a required check is never skipped/stuck.)

## Testing

`mdformat --check docs/`, `codespell docs/`, and the hidden-char grep all pass locally. Docs-only + CI change; `zensical` build not run locally (not installed in my env).

Closes #83