### PR TITLE
docs: expand the development environment page (SAM, CDK, testing, agentic)

### DIFF
--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -1,8 +1,12 @@
 # Development Environment
 
-This page covers how to set up your environment, wire up the local development loop,
-configure a durable function, deploy it with infrastructure as code, and use the AI
-agent (Kiro Power) that the team ships for building durable functions.
+This page covers the day-to-day workflow for building durable functions: scaffolding a
+project, writing and testing the function locally, and deploying it. It uses the
+[AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) for the local
+development loop — `sam init` to start, `sam local invoke` to run, and `sam deploy` to
+ship — and the [AWS CDK](https://docs.aws.amazon.com/cdk/) when you productionize the
+surrounding infrastructure. It also covers the AI agent (Kiro Power) the team ships for
+building durable functions.
 
 If you just want to deploy your first function with the AWS CLI, start with the
 [Quickstart](quickstart.md). This page is about the day-to-day workflow after that.
@@ -43,19 +47,33 @@ full workflow.
 - An AWS account and the [AWS CLI](https://docs.aws.amazon.com/cli/) (2.33.22 or later)
     configured with credentials. Verify with `aws sts get-caller-identity`.
 - A language runtime (see the tabs below).
-- One way to deploy: the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/)
-    (1.153.1 or later), the [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or
-    later), or direct AWS CLI access.
+- The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) (1.153.1
+    or later), used throughout this guide to scaffold, test, and deploy. The
+    [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or later) is recommended once you
+    productionize the surrounding infrastructure. Direct AWS CLI access also works.
 
 ## 1. Write Function
 
-Write your durable function handler and add the SDK to your project. Bundle the SDK with
-your function code so you control the exact version, rather than relying on the Lambda
-runtime-provided copy. The Lambda runtime-provided SDK lags behind the public
-`aws-durable-execution-sdk-*` version releases on public package indices (e.g. NPM, PyPI, Maven, Nuget, ...). It can be unclear which SDK version
-the runtime provides, which features or bug fixes are present. For the full handler code
-in each language, see the
-[Quickstart](quickstart.md).
+Scaffold a new durable application with `sam init`. Its AWS Quick Start templates include
+durable-function starters for TypeScript, Python, and Java that generate the handler, a
+`template.yaml` with `DurableConfig` already set, a `tests` folder, and the SDK
+dependency:
+
+```console
+sam init
+```
+
+Choose **AWS Quick Start Templates**, pick the durable function template, then select your
+runtime. See
+[Create your application in AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/using-sam-cli-init.html)
+for the interactive flow, and the [Quickstart](quickstart.md) for the full handler code in
+each language.
+
+Bundle the SDK with your function code so you control the exact version, rather than
+relying on the Lambda runtime-provided copy. The Lambda runtime-provided SDK lags behind
+the public `aws-durable-execution-sdk-*` version releases on public package indices (e.g.
+NPM, PyPI, Maven, Nuget, ...). It can be unclear which SDK version the runtime provides,
+which features or bug fixes are present. To add or pin the SDK manually:
 
 === "TypeScript"
 
@@ -174,12 +192,14 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-For anything beyond a first experiment, we recommend you deploy with SAM or CDK whilst storing your function
-configuration, IAM role, version, alias and any related infrastructure in source control. This allows you to iterate quickly whilst reducing the additional work you'll have to do to take your work to production. Tune `DurableConfig`
-per environment: short timeouts and retention in development, longer values in
-production.
+Deploy with SAM while you iterate: it keeps your function configuration, IAM role,
+version, and alias in source control with minimal ceremony, and pairs with the
+`sam local invoke` / `sam deploy` loop. When you productionize — composing the function
+with the rest of your infrastructure (queues, tables, alarms, multi-environment stages) —
+AWS CDK gives you a typed, programmable app. Tune `DurableConfig` per environment: short
+timeouts and retention in development, longer values in production.
 
-=== "SAM"
+=== "SAM (iterate)"
 
     `template.yaml`:
 
@@ -216,7 +236,7 @@ production.
     `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
     invocation requires.
 
-=== "CDK"
+=== "CDK (productionize)"
 
     ```typescript
     import * as cdk from 'aws-cdk-lib';

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -1,6 +1,6 @@
 # Development Environment
 
-This page covers how to set up your environment, wire up the inner development loop,
+This page covers how to set up your environment, wire up the local development loop,
 configure a durable function, deploy it with infrastructure as code, and use the AI
 agent (Kiro Power) that the team ships for building durable functions.
 
@@ -11,7 +11,7 @@ If you just want to deploy your first function with the AWS CLI, start with the
 
 You develop durable functions in a tight inner loop: write the function, write tests,
 and run them locally before you deploy. Once deployed, you run the same tests against
-the live function to validate packaging and runtime configuration.
+the deployed function to validate packaging and runtime configuration.
 
 ```mermaid
 flowchart LR
@@ -34,7 +34,7 @@ flowchart LR
     style prod fill:#fff3e0
 ```
 
-The local runner replays your handler in-process, so you catch determinism bugs in
+The local runner replays your handler in-process, so you catch bugs in
 milliseconds instead of waiting on a deploy. See [Testing](../testing/index.md) for the
 full workflow.
 
@@ -50,8 +50,8 @@ full workflow.
 ## Write Function
 
 Write your durable function handler and add the SDK to your project. Bundle the SDK with
-your function code so you control the exact version, rather than relying on the
-runtime-provided copy. For the full handler code in each language, see the
+your function code so you control the exact version, rather than relying on the Lambda 
+runtime-provided copy. The Lambda runtime-provided SDK version updates lag behind our aws-durable-execution-sdk-* package updates, it can unclear what version of the SDK the runtime has and what features/bug-fixes are present. For the full handler code in each language, see the
 [Quickstart](quickstart.md).
 
 === "TypeScript"
@@ -143,20 +143,18 @@ and [workflow patterns](../testing/workflow-patterns.md).
 
 ## Deploy
 
-Durable execution must be enabled when the function is created — it cannot be added to an
-existing function later. Every durable function needs three things, whichever tool you
+You can only set the DurableConfig at function creation time, not at a later update. Every durable function needs three things, whichever tool you
 deploy with:
 
 1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
-    `RetentionPeriodInDays` is optional). See the
-    [configuration reference](../sdk-reference/configuration/index.md).
+    `RetentionPeriodInDays` is optional). See the https://docs.aws.amazon.com/lambda/latest/dg/durable-configuration.html.
 1. The
     [AWSLambdaBasicDurableExecutionRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)
     managed policy on the execution role, which grants the checkpoint permissions.
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-For anything beyond a first experiment, deploy with SAM or CDK so your function
+For anything beyond a first experiment, we recommend you deploy with SAM or CDK so your function
 configuration, IAM role, version, and alias live in source control. Tune `DurableConfig`
 per environment: short timeouts and retention in development, longer values in
 production.
@@ -235,15 +233,14 @@ production.
     cdk deploy
     ```
 
-You can also use plain CloudFormation (`AWS::Lambda::Function` with a `DurableConfig`
+You can also use CloudFormation (`AWS::Lambda::Function` with a `DurableConfig`
 property). For durable invokes, callbacks, multi-environment stages, and log-group
 management, see the deployment guidance in the
 [Kiro Power](#agentic-development-with-kiro) below.
 
 ## Test in Cloud
 
-After deploying, validate the real packaging and runtime configuration — not just the
-in-process handler.
+After deploying, validate using Lambda in the cloud.
 
 - Run your test suite against the deployed function with the
     [Cloud Runner](../testing/cloud-runner.md).
@@ -261,8 +258,8 @@ in-process handler.
 
 ## Agentic development with Kiro
 
-The team ships a [Kiro](https://kiro.dev) Power,
-**AWS Lambda durable functions**, that teaches an AI coding assistant the replay model,
+The [Kiro](https://kiro.dev) Power for
+**AWS Lambda durable functions** helps your AI coding assistant understand the replay model,
 step and wait patterns, error handling, testing, and IaC for durable functions. It is
 the fastest way to write correct durable functions with an agent, because it front-loads
 the determinism rules that are easy to get wrong.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -17,15 +17,15 @@ the live function to validate packaging and runtime configuration.
 flowchart LR
     subgraph dev["Development (Local)"]
         direction LR
-        A["Install the SDK"]
-        B["Write and test locally"]
-        C["Configure your function"]
+        A["Write Function"]
+        B["Write Tests"]
+        C["Run Tests"]
     end
 
     subgraph prod["Production (AWS)"]
         direction LR
-        D["Deploy with infrastructure as code"]
-        E["Test against the cloud"]
+        D["Deploy"]
+        E["Test in Cloud"]
     end
 
     A --> B --> C --> D --> E
@@ -47,10 +47,12 @@ full workflow.
     (1.153.1 or later), the [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or
     later), or direct AWS CLI access.
 
-## Install the SDK
+## Write Function
 
-Add the SDK to your project. Bundle it with your function code so you control the exact
-version, rather than relying on the runtime-provided copy.
+Write your durable function handler and add the SDK to your project. Bundle the SDK with
+your function code so you control the exact version, rather than relying on the
+runtime-provided copy. For the full handler code in each language, see the
+[Quickstart](quickstart.md).
 
 === "TypeScript"
 
@@ -89,11 +91,11 @@ version, rather than relying on the runtime-provided copy.
     dotnet add package Amazon.Lambda.DurableExecution
     ```
 
-## Write and test locally
+## Write Tests
 
-Write your handler, then drive it with the testing SDK. The runner executes the handler
-through the same replay-and-checkpoint loop the Lambda service uses, so local behavior
-matches the cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
+Drive your handler with the testing SDK. The runner executes the handler through the
+same replay-and-checkpoint loop the Lambda service uses, so local behavior matches the
+cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
 `DurableFunctionTestRunner`.
 
 A minimal test creates a runner with your handler, runs it, and asserts on the result:
@@ -122,6 +124,8 @@ A minimal test creates a runner with your handler, runs it, and asserts on the r
     --8<-- "examples/csharp/testing/authoring/minimal-test.cs"
     ```
 
+## Run Tests
+
 Run the suite with your language's test runner:
 
 ```console
@@ -137,9 +141,11 @@ replay behavior. The [Testing](../testing/index.md) section covers installing th
 SDK, [authoring tests](../testing/authoring.md), [assertions](../testing/assertions.md),
 and [workflow patterns](../testing/workflow-patterns.md).
 
-## Configure your function
+## Deploy
 
-Every durable function needs three things, whichever tool you deploy with:
+Durable execution must be enabled when the function is created — it cannot be added to an
+existing function later. Every durable function needs three things, whichever tool you
+deploy with:
 
 1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
     `RetentionPeriodInDays` is optional). See the
@@ -150,14 +156,10 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-Durable execution must be enabled when the function is created — it cannot be added to an
-existing function later. Tune `DurableConfig` per environment: short timeouts and
-retention in development, longer values in production.
-
-## Deploy with infrastructure as code
-
 For anything beyond a first experiment, deploy with SAM or CDK so your function
-configuration, IAM role, version, and alias live in source control.
+configuration, IAM role, version, and alias live in source control. Tune `DurableConfig`
+per environment: short timeouts and retention in development, longer values in
+production.
 
 === "SAM"
 
@@ -238,7 +240,7 @@ property). For durable invokes, callbacks, multi-environment stages, and log-gro
 management, see the deployment guidance in the
 [Kiro Power](#agentic-development-with-kiro) below.
 
-## Test against the cloud
+## Test in Cloud
 
 After deploying, validate the real packaging and runtime configuration — not just the
 in-process handler.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -3,8 +3,8 @@
 This page covers the day-to-day workflow for building durable functions: scaffolding a
 project, writing and testing the function locally, and deploying it. It uses the
 [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) for the local
-development loop — `sam init` to start, `sam local invoke` to run, and `sam deploy` to
-ship — and the [AWS CDK](https://docs.aws.amazon.com/cdk/) when you productionize the
+development loop (`sam init` to start, `sam local invoke` to run, and `sam deploy` to
+ship) and the [AWS CDK](https://docs.aws.amazon.com/cdk/) when you productionize the
 surrounding infrastructure. It also covers the AI agent (Kiro Power) the team ships for
 building durable functions.
 
@@ -193,12 +193,12 @@ Every durable function needs three things, whichever tool you deploy with:
     supported on an unqualified function name.
 
 Deploy with SAM while you iterate: it declares your function configuration, IAM role,
-version, and alias in a single `template.yaml` — one place you can check into source
-control — and pairs with the `sam local invoke` / `sam deploy` loop. When you
-productionize — composing the function with the rest of your infrastructure (queues,
-tables, alarms, multi-environment stages) — AWS CDK gives you a typed, programmable app.
-Tune `DurableConfig` per environment: short timeouts and retention in development, longer
-values in production.
+version, and alias in a single `template.yaml`, one place you can check into source
+control, and pairs with the `sam local invoke` / `sam deploy` loop. When you productionize
+(composing the function with the rest of your infrastructure, such as queues, tables,
+alarms, and multi-environment stages), AWS CDK gives you a typed, programmable app. Tune
+`DurableConfig` per environment: short timeouts and retention in development, longer values
+in production.
 
 === "SAM (iterate)"
 
@@ -290,7 +290,7 @@ After deploying, validate using Lambda in the cloud.
     [SAM CLI](../testing/sam-cli.md):
 
     ```console
-    # Local container invoke — no deployment needed
+    # Local container invoke (no deployment needed)
     sam local invoke MyDurableFunction --durable-execution-name my-test
 
     # Remote invoke against a deployed function

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -5,8 +5,8 @@ project, writing and testing the function locally, and deploying it. It uses the
 [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) for the local
 development loop (`sam init` to start, `sam local invoke` to run, and `sam deploy` to
 ship) and the [AWS CDK](https://docs.aws.amazon.com/cdk/) when you productionize the
-surrounding infrastructure. It also covers the AI agent (Kiro Power) the team ships for
-building durable functions.
+surrounding infrastructure. It also covers the AI agent tooling (the Agent Toolkit for
+AWS) the team ships for building durable functions.
 
 If you just want to deploy your first function with the AWS CLI, start with the
 [Quickstart](quickstart.md). This page is about the day-to-day workflow after that.
@@ -241,13 +241,29 @@ replay behavior. The [Testing](../testing/index.md) section covers installing th
 SDK, [authoring tests](../testing/authoring.md), [assertions](../testing/assertions.md),
 and [workflow patterns](../testing/workflow-patterns.md).
 
+### Invoke locally with the SAM CLI
+
+The test runner exercises your handler in-process. To run the packaged function in a
+local container that matches the Lambda runtime, build it first, then invoke it with the
+[SAM CLI](../testing/sam-cli.md). This needs no deployment and no AWS credentials:
+
+```console
+sam build
+sam local invoke MyDurableFunction --durable-execution-name my-test
+```
+
 ## 4. Deploy
 
-You can only set the `DurableConfig` at function creation time, not on a later update.
+You set the `DurableConfig` when the function is created. Adding it to an existing
+function triggers a resource replacement, which only succeeds when the function name is
+not explicitly set in the template; changing values inside an existing `DurableConfig`
+does not. See
+[Lambda with durable configuration](https://github.com/aws/aws-cdk/tree/main/packages/aws-cdk-lib/aws-lambda#lambda-with-durable-configuration)
+in the CDK docs for details.
 Every durable function needs three things, whichever tool you deploy with:
 
 1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
-    `RetentionPeriodInDays` is optional). See the
+    `RetentionPeriodInDays` is optional and defaults to 14 days). See the
     [durable configuration reference](https://docs.aws.amazon.com/lambda/latest/dg/durable-configuration.html).
 1. The
     [AWSLambdaBasicDurableExecutionRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)
@@ -255,11 +271,12 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-Deploy with SAM while you iterate: it declares your function configuration, IAM role,
-version, and alias in a single `template.yaml`, one place you can check into source
-control, and pairs with the `sam local invoke` / `sam deploy` loop. When you productionize
-(composing the function with the rest of your infrastructure, such as queues, tables,
-alarms, and multi-environment stages), AWS CDK gives you a typed, programmable app. Tune
+Both SAM and CDK can deploy durable functions to production. SAM is great for iterating
+on a single function: it declares your function configuration, IAM role, version, and
+alias in a single `template.yaml`, one place you can check into source control, and pairs
+with the `sam local invoke` / `sam deploy` loop. For more complex systems (composing the
+function with the rest of your infrastructure, such as queues, tables, alarms, and
+multi-environment stages), AWS CDK gives you a typed, programmable app. Tune
 `DurableConfig` per environment: short timeouts and retention in development, longer values
 in production.
 
@@ -374,7 +391,7 @@ in production.
 You can also use CloudFormation directly (`AWS::Lambda::Function` with a `DurableConfig`
 property). For durable invokes, callbacks, multi-environment stages, and log-group
 management, see the deployment guidance in the
-[Kiro Power](#agentic-development-with-kiro) below.
+[Agent Toolkit](#agentic-development-with-kiro) below.
 
 ## 5. Test in Cloud
 
@@ -383,42 +400,41 @@ After deploying, validate using Lambda in the cloud.
 - Run your test suite against the deployed function with the
     [Cloud Runner](../testing/cloud-runner.md).
 
-- Invoke locally in a container, or against the deployed function, with the
-    [SAM CLI](../testing/sam-cli.md):
+- Invoke the deployed function with the [SAM CLI](../testing/sam-cli.md):
 
     ```console
-    # Local container invoke (no deployment needed)
-    sam local invoke MyDurableFunction --durable-execution-name my-test
-
-    # Remote invoke against a deployed function
     sam remote invoke MyDurableFunction --stack-name my-stack --event '{"name": "world"}'
     ```
 
 ## Agentic development with Kiro
 
-The [Kiro](https://kiro.dev) Power for
-**AWS Lambda durable functions** helps your AI coding assistant understand the replay model,
-step and wait patterns, error handling, testing, and IaC for durable functions. It is
-the fastest way to write correct durable functions with an agent, because it front-loads
-the determinism rules that are easy to get wrong.
+The [Agent Toolkit for AWS](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/what-is-agent-toolkit.html)
+ships a **Lambda durable functions** skill that teaches your AI coding assistant the
+replay model, step and wait patterns, error handling, testing, and IaC for durable
+functions. It is the fastest way to write correct durable functions with an agent,
+because it front-loads the determinism rules that are easy to get wrong.
 
-Install it from [kiro.dev/powers](https://kiro.dev/powers) or from your IDE, then
-build workflows from natural language prompts:
+Install it by following the
+[agent setup guide](https://docs.aws.amazon.com/lambda/latest/dg/agent-setup-guide.html),
+which covers Kiro, Claude Code, Cursor, GitHub Copilot, Codex, and other agents. Once
+installed, build workflows from natural language prompts:
 
 ```
 Help me create a durable Lambda function that processes orders with retries
 ```
 
-Kiro loads the relevant guidance and walks through the handler, steps with retry
+The agent loads the relevant guidance and walks through the handler, steps with retry
 strategies, error handling, tests with the local runner, and deployment. Mentioning
 keywords such as `durable`, `workflow`, `saga`, `agentic`, `human-in-the-loop`, or
-`callback` activates the Power automatically.
+`callback` activates the durable functions skill.
 
-If you use another AI assistant, the same guidance is available as Markdown steering
-files in the
-[aws-lambda-durable-functions-power](https://github.com/aws/aws-durable-execution-docs/tree/main/aws-lambda-durable-functions-power)
-directory of this repository. You can load these files as context to get the same replay-model and
-deployment rules.
+For any agent that supports the open
+[agent skills](https://agentskills.io/specification) format, you can add the durable
+functions skill directly:
+
+```console
+npx skills add https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/serverless-skills/aws-lambda-durable-functions --yes --global
+```
 
 ## Next steps
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -245,12 +245,24 @@ and [workflow patterns](../testing/workflow-patterns.md).
 
 The test runner exercises your handler in-process. To run the packaged function in a
 local container that matches the Lambda runtime, build it first, then invoke it with the
-[SAM CLI](../testing/sam-cli.md). This needs no deployment and no AWS credentials:
+[SAM CLI](https://docs.aws.amazon.com/durable-execution/testing/sam-cli/#sam-cli). This
+needs no deployment and no AWS credentials:
 
 ```console
 sam build
+
+# Invoke the function; --durable-execution-name names the execution so you can inspect it
 sam local invoke MyDurableFunction --durable-execution-name my-test
+
+# Print the execution's checkpoint and operation history (steps, waits, callbacks)
+sam local execution history <execution-id>
+
+# Resolve a pending callback so an execution waiting on it resumes
+sam local callback succeed <callback-id>
 ```
+
+For the full command reference, see
+[SAM CLI](https://docs.aws.amazon.com/durable-execution/testing/sam-cli/#sam-cli).
 
 ## 4. Deploy
 
@@ -400,11 +412,22 @@ After deploying, validate using Lambda in the cloud.
 - Run your test suite against the deployed function with the
     [Cloud Runner](../testing/cloud-runner.md).
 
-- Invoke the deployed function with the [SAM CLI](../testing/sam-cli.md):
+- Invoke the deployed function with the
+    [SAM CLI](https://docs.aws.amazon.com/durable-execution/testing/sam-cli/#sam-cli):
 
     ```console
+    # Invoke the deployed function in the cloud
     sam remote invoke MyDurableFunction --stack-name my-stack --event '{"name": "world"}'
+
+    # Print the deployed execution's checkpoint and operation history
+    sam remote execution history <execution-id>
+
+    # Resolve a pending callback (pass the result the waiting execution expects)
+    sam remote callback succeed <callback-id> --result '"approved"'
     ```
+
+    For the full command reference, see
+    [SAM CLI](https://docs.aws.amazon.com/durable-execution/testing/sam-cli/#sam-cli).
 
 ## Agentic development with Kiro
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -17,15 +17,15 @@ the live function to validate packaging and runtime configuration.
 flowchart LR
     subgraph dev["Development (Local)"]
         direction LR
-        A["1. Write Function"]
-        B["2. Write Tests"]
-        C["3. Run Tests"]
+        A["Install the SDK"]
+        B["Write and test locally"]
+        C["Configure your function"]
     end
 
     subgraph prod["Production (AWS)"]
         direction LR
-        D["4. Deploy"]
-        E["5. Test in Cloud"]
+        D["Deploy with infrastructure as code"]
+        E["Test against the cloud"]
     end
 
     A --> B --> C --> D --> E

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -420,7 +420,7 @@ After deploying, validate using Lambda in the cloud.
     sam remote invoke MyDurableFunction --stack-name my-stack --event '{"name": "world"}'
 
     # Print the deployed execution's checkpoint and operation history
-    sam remote execution history <execution-id>
+    sam remote execution history <execution-arn>
 
     # Resolve a pending callback (pass the result the waiting execution expects)
     sam remote callback succeed <callback-id> --result '"approved"'

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -72,10 +72,8 @@ for the interactive flow, and the [Quickstart](quickstart.md) for the full handl
 each language.
 
 Bundle the SDK with your function code so you control the exact version, rather than
-relying on the Lambda runtime-provided copy. The Lambda runtime-provided SDK lags behind
-the public `aws-durable-execution-sdk-*` version releases on public package indices (e.g.
-NPM, PyPI, Maven, Nuget, ...). It can be unclear which SDK version the runtime provides,
-which features or bug fixes are present. To add or pin the SDK manually:
+relying on the Lambda runtime-provided copy. This gives you control over which version of the
+SDK is being deployed in your function code, rather than relying on which is being bundled in the lambda runtime.
 
 === "TypeScript"
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -1,6 +1,17 @@
 # Development Environment
 
+This page covers how to set up your environment, wire up the inner development loop,
+configure a durable function, deploy it with infrastructure as code, and use the AI
+agent (Kiro Power) that the team ships for building durable functions.
+
+If you just want to deploy your first function with the AWS CLI, start with the
+[Quickstart](quickstart.md). This page is about the day-to-day workflow after that.
+
 ## Development workflow
+
+You develop durable functions in a tight inner loop: write the function, write tests,
+and run them locally before you deploy. Once deployed, you run the same tests against
+the live function to validate packaging and runtime configuration.
 
 ```mermaid
 flowchart LR
@@ -10,15 +21,251 @@ flowchart LR
         B["2. Write Tests"]
         C["3. Run Tests"]
     end
-    
+
     subgraph prod["Production (AWS)"]
         direction LR
         D["4. Deploy"]
         E["5. Test in Cloud"]
     end
-    
+
     A --> B --> C --> D --> E
-    
+
     style dev fill:#e3f2fd
     style prod fill:#fff3e0
 ```
+
+The local runner replays your handler in-process, so you catch determinism bugs in
+milliseconds instead of waiting on a deploy. See [Testing](../testing/index.md) for the
+full workflow.
+
+## Prerequisites
+
+- An AWS account and the [AWS CLI](https://docs.aws.amazon.com/cli/) (2.33.22 or later)
+    configured with credentials. Verify with `aws sts get-caller-identity`.
+- A language runtime (see the tabs below).
+- One way to deploy: the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/)
+    (1.153.1 or later), the [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or
+    later), or direct AWS CLI access.
+
+## Install the SDK
+
+Add the SDK to your project. Bundle it with your function code so you control the exact
+version, rather than relying on the runtime-provided copy.
+
+=== "TypeScript"
+
+    Requires Node.js 22+.
+
+    ```console
+    npm install @aws/durable-execution-sdk-js
+    ```
+
+=== "Python"
+
+    Requires Python 3.13+ (3.11 is the minimum the SDK supports; runtimes 3.13+ ship
+    the SDK pre-installed).
+
+    ```console
+    pip install aws-durable-execution-sdk-python
+    ```
+
+=== "Java"
+
+    Requires Java 17+ and Maven 3.8+. Add to your `pom.xml`:
+
+    ```xml
+    <dependency>
+        <groupId>software.amazon.lambda.durable</groupId>
+        <artifactId>aws-durable-execution-sdk-java</artifactId>
+        <version>1.1.0</version>
+    </dependency>
+    ```
+
+=== "C#"
+
+    Requires the .NET 10 SDK.
+
+    ```console
+    dotnet add package Amazon.Lambda.DurableExecution
+    ```
+
+## Write and test locally
+
+Write your handler, then drive it with the testing SDK. The runner executes the handler
+through the same replay-and-checkpoint loop the Lambda service uses, so local behavior
+matches the cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
+`DurableFunctionTestRunner`.
+
+```console
+# TypeScript / Jest
+npm test
+
+# Python / pytest
+pytest
+```
+
+Get operations by name (never by index) and invoke the runner more than once to assert
+replay behavior. The [Testing](../testing/index.md) section covers installing the testing
+SDK, [authoring tests](../testing/authoring.md), [assertions](../testing/assertions.md),
+and [workflow patterns](../testing/workflow-patterns.md).
+
+## Configure your function
+
+Every durable function needs three things, whichever tool you deploy with:
+
+1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
+    `RetentionPeriodInDays` is optional). See the
+    [configuration reference](../sdk-reference/configuration/index.md) for the valid
+    ranges and defaults.
+1. The
+    [AWSLambdaBasicDurableExecutionRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)
+    managed policy on the execution role, which grants the checkpoint permissions.
+1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
+    supported on an unqualified function name.
+
+Durable execution must be enabled when the function is created — it cannot be added to an
+existing function later. Tune `DurableConfig` per environment: short timeouts and
+retention in development, longer values in production.
+
+## Deploy with infrastructure as code
+
+For anything beyond a first experiment, deploy with SAM or CDK so your function
+configuration, IAM role, version, and alias live in source control.
+
+=== "SAM"
+
+    `template.yaml`:
+
+    ```yaml
+    AWSTemplateFormatVersion: '2010-09-09'
+    Transform: AWS::Serverless-2016-10-31
+
+    Resources:
+      DurableFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+          Runtime: nodejs22.x
+          Handler: index.handler
+          CodeUri: ./src
+          DurableConfig:
+            ExecutionTimeout: 3600
+            RetentionPeriodInDays: 7
+          Policies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          AutoPublishAlias: prod
+
+    Outputs:
+      AliasArn:
+        Value: !Ref DurableFunction.Alias
+    ```
+
+    Deploy:
+
+    ```console
+    sam build
+    sam deploy --guided
+    ```
+
+    `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
+    invocation requires.
+
+=== "CDK"
+
+    ```typescript
+    import * as cdk from 'aws-cdk-lib';
+    import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+    export class DurableFunctionStack extends cdk.Stack {
+      constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const fn = new lambda.Function(this, 'DurableFunction', {
+          runtime: lambda.Runtime.NODEJS_22_X,
+          handler: 'index.handler',
+          code: lambda.Code.fromAsset('lambda'),
+          durableConfig: {
+            executionTimeout: cdk.Duration.hours(1),
+            retentionPeriod: cdk.Duration.days(7),
+          },
+        });
+
+        // CDK adds the checkpoint permissions automatically when durableConfig is set.
+        const alias = new lambda.Alias(this, 'ProdAlias', {
+          aliasName: 'prod',
+          version: fn.currentVersion,
+        });
+
+        new cdk.CfnOutput(this, 'AliasArn', { value: alias.functionArn });
+      }
+    }
+    ```
+
+    Deploy:
+
+    ```console
+    cdk deploy
+    ```
+
+You can also use plain CloudFormation (`AWS::Lambda::Function` with a `DurableConfig`
+property). For durable invokes, callbacks, multi-environment stages, and log-group
+management, see the deployment guidance in the
+[Kiro Power](#agentic-development-with-kiro) below.
+
+## Test against the cloud
+
+After deploying, validate the real packaging and runtime configuration — not just the
+in-process handler.
+
+- Run your test suite against the deployed function with the
+    [Cloud Runner](../testing/cloud-runner.md).
+
+- Invoke locally in a container, or against the deployed function, with the
+    [SAM CLI](../testing/sam-cli.md):
+
+    ```console
+    # Local container invoke — no deployment needed
+    sam local invoke MyDurableFunction --durable-execution-name my-test
+
+    # Remote invoke against a deployed function
+    sam remote invoke MyDurableFunction --stack-name my-stack --event '{"name": "world"}'
+    ```
+
+## Agentic development with Kiro
+
+The team ships a [Kiro](https://kiro.dev) Power,
+**AWS Lambda durable functions**, that teaches an AI coding assistant the replay model,
+step and wait patterns, error handling, testing, and IaC for durable functions. It is
+the fastest way to write correct durable functions with an agent, because it front-loads
+the determinism rules that are easy to get wrong.
+
+Install it from [kiro.dev/powers](https://kiro.dev/powers) or from your IDE, then
+describe what you want to build:
+
+```
+Help me create a durable Lambda function that processes orders with retries
+```
+
+Kiro loads the relevant guidance and walks through the handler, steps with retry
+strategies, error handling, tests with the local runner, and deployment. Mentioning
+keywords such as `durable`, `workflow`, `saga`, `agentic`, `human-in-the-loop`, or
+`callback` activates the Power automatically.
+
+Durable functions are themselves a strong fit for **agentic** workloads: a GenAI loop
+that calls tools, waits on human approval, and runs for hours or days survives
+interruption and resumes from the last checkpoint. The Power includes patterns for
+GenAI agent loops and human-in-the-loop approvals.
+
+If you use another AI assistant, the same guidance is available as Markdown steering
+files in the
+[aws-lambda-durable-functions-power](https://github.com/aws/aws-durable-execution-docs/tree/main/aws-lambda-durable-functions-power)
+directory of this repository — load them as context to get the same replay-model and
+deployment rules.
+
+## Next steps
+
+- [Quickstart](quickstart.md) deploy your first durable function with the AWS CLI
+- [Key Concepts](key-concepts.md) replay, checkpoints, and determinism
+- [Testing](../testing/index.md) the runner, authoring tests, and assertions
+- [Configuration](../sdk-reference/configuration/index.md) `DurableConfig` and the
+    Lambda client
+- [Manage Executions](manage-executions.md) list, inspect, stop, and clean up

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -283,122 +283,82 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-Both SAM and CDK can deploy durable functions to production. SAM is great for iterating
-on a single function: it declares your function configuration, IAM role, version, and
-alias in a single `template.yaml`, one place you can check into source control, and pairs
-with the `sam local invoke` / `sam deploy` loop. For more complex systems (composing the
-function with the rest of your infrastructure, such as queues, tables, alarms, and
-multi-environment stages), AWS CDK gives you a typed, programmable app. Tune
-`DurableConfig` per environment: short timeouts and retention in development, longer values
-in production.
+This guide deploys with SAM. SAM is great for iterating on a single function: it declares
+your function configuration, IAM role, version, and alias in a single `template.yaml`
+(one place you can check into source control) and pairs with the `sam local invoke` /
+`sam deploy` loop. For committing and composing more complex infrastructure beyond a
+single Lambda function (queues, tables, alarms, multi-environment stages), use the
+[AWS CDK](https://docs.aws.amazon.com/cdk/) instead. Tune `DurableConfig` per environment:
+short timeouts and retention in development, longer values in production.
 
-=== "SAM (iterate)"
+`template.yaml`:
 
-    `template.yaml`:
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  DurableFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: nodejs22.x
+      Handler: index.handler
+      CodeUri: ./src
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Policies:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+      AutoPublishAlias: prod
+
+Outputs:
+  AliasArn:
+    Value: !Ref DurableFunction.Alias
+```
+
+Deploy:
+
+```console
+sam build
+sam deploy --guided
+```
+
+`AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
+invocation requires.
+
+`sam build` prepares your handler before packaging. What it needs depends on the
+language:
+
+=== "TypeScript"
+
+    Add an esbuild build method so `sam build` transpiles TypeScript. Without it, SAM
+    ships the `.ts` source, which only works for plain JavaScript:
 
     ```yaml
-    AWSTemplateFormatVersion: '2010-09-09'
-    Transform: AWS::Serverless-2016-10-31
-
-    Resources:
-      DurableFunction:
-        Type: AWS::Serverless::Function
-        Properties:
-          Runtime: nodejs22.x
-          Handler: index.handler
-          CodeUri: ./src
-          DurableConfig:
-            ExecutionTimeout: 3600
-            RetentionPeriodInDays: 7
-          Policies:
-            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
-          AutoPublishAlias: prod
-
-    Outputs:
-      AliasArn:
-        Value: !Ref DurableFunction.Alias
+    DurableFunction:
+      Type: AWS::Serverless::Function
+      # Properties as above
+      Metadata:
+        BuildMethod: esbuild
+        BuildProperties:
+          Format: cjs
+          Target: node22
+          EntryPoints:
+            - index.ts
     ```
 
-    Deploy:
+=== "Python"
 
-    ```console
-    sam build
-    sam deploy --guided
-    ```
+    No build method is required. `sam build` installs dependencies from
+    `requirements.txt` and packages the source.
 
-    `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
-    invocation requires.
+=== "Java"
 
-    `sam build` prepares your handler before packaging. What it needs depends on the
-    language:
+    `sam build` builds with Maven or Gradle from your `pom.xml` or `build.gradle`.
 
-    === "TypeScript"
+=== "C#"
 
-        Add an esbuild build method so `sam build` transpiles TypeScript. Without it, SAM
-        ships the `.ts` source, which only works for plain JavaScript:
-
-        ```yaml
-        DurableFunction:
-          Type: AWS::Serverless::Function
-          # Properties as above
-          Metadata:
-            BuildMethod: esbuild
-            BuildProperties:
-              Format: cjs
-              Target: node22
-              EntryPoints:
-                - index.ts
-        ```
-
-    === "Python"
-
-        No build method is required. `sam build` installs dependencies from
-        `requirements.txt` and packages the source.
-
-    === "Java"
-
-        `sam build` builds with Maven or Gradle from your `pom.xml` or `build.gradle`.
-
-    === "C#"
-
-        `sam build` builds with the .NET CLI.
-
-=== "CDK"
-
-    ```typescript
-    import * as cdk from 'aws-cdk-lib';
-    import * as lambda from 'aws-cdk-lib/aws-lambda';
-
-    export class DurableFunctionStack extends cdk.Stack {
-      constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
-        super(scope, id, props);
-
-        const fn = new lambda.Function(this, 'DurableFunction', {
-          runtime: lambda.Runtime.NODEJS_22_X,
-          handler: 'index.handler',
-          code: lambda.Code.fromAsset('lambda'),
-          durableConfig: {
-            executionTimeout: cdk.Duration.hours(1),
-            retentionPeriod: cdk.Duration.days(7),
-          },
-        });
-
-        // CDK adds the checkpoint permissions automatically when durableConfig is set.
-        const alias = new lambda.Alias(this, 'ProdAlias', {
-          aliasName: 'prod',
-          version: fn.currentVersion,
-        });
-
-        new cdk.CfnOutput(this, 'AliasArn', { value: alias.functionArn });
-      }
-    }
-    ```
-
-    Deploy:
-
-    ```console
-    cdk deploy
-    ```
+    `sam build` builds with the .NET CLI.
 
 You can also use CloudFormation directly (`AWS::Lambda::Function` with a `DurableConfig`
 property). For durable invokes, callbacks, multi-environment stages, and log-group

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -96,6 +96,34 @@ through the same replay-and-checkpoint loop the Lambda service uses, so local be
 matches the cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
 `DurableFunctionTestRunner`.
 
+A minimal test creates a runner with your handler, runs it, and asserts on the result:
+
+=== "TypeScript"
+
+    ```typescript
+    --8<-- "examples/typescript/testing/authoring/minimal-test.ts"
+    ```
+
+=== "Python"
+
+    ```python
+    --8<-- "examples/python/testing/authoring/minimal-test.py"
+    ```
+
+=== "Java"
+
+    ```java
+    --8<-- "examples/java/testing/authoring/minimal-test.java"
+    ```
+
+=== "C#"
+
+    ```csharp
+    --8<-- "examples/csharp/testing/authoring/minimal-test.cs"
+    ```
+
+Run the suite with your language's test runner:
+
 ```console
 # TypeScript / Jest
 npm test

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -283,82 +283,122 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-This guide deploys with SAM. SAM is great for iterating on a single function: it declares
-your function configuration, IAM role, version, and alias in a single `template.yaml`
-(one place you can check into source control) and pairs with the `sam local invoke` /
-`sam deploy` loop. For committing and composing more complex infrastructure beyond a
-single Lambda function (queues, tables, alarms, multi-environment stages), use the
-[AWS CDK](https://docs.aws.amazon.com/cdk/) instead. Tune `DurableConfig` per environment:
-short timeouts and retention in development, longer values in production.
+Both SAM and CDK can deploy durable functions to production. SAM is great for iterating
+on a single function: it declares your function configuration, IAM role, version, and
+alias in a single `template.yaml`, one place you can check into source control, and pairs
+with the `sam local invoke` / `sam deploy` loop. For more complex systems (composing the
+function with the rest of your infrastructure, such as queues, tables, alarms, and
+multi-environment stages), AWS CDK gives you a typed, programmable app. Tune
+`DurableConfig` per environment: short timeouts and retention in development, longer values
+in production.
 
-`template.yaml`:
+=== "SAM (iterate)"
 
-```yaml
-AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
-
-Resources:
-  DurableFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Runtime: nodejs22.x
-      Handler: index.handler
-      CodeUri: ./src
-      DurableConfig:
-        ExecutionTimeout: 3600
-        RetentionPeriodInDays: 7
-      Policies:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
-      AutoPublishAlias: prod
-
-Outputs:
-  AliasArn:
-    Value: !Ref DurableFunction.Alias
-```
-
-Deploy:
-
-```console
-sam build
-sam deploy --guided
-```
-
-`AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
-invocation requires.
-
-`sam build` prepares your handler before packaging. What it needs depends on the
-language:
-
-=== "TypeScript"
-
-    Add an esbuild build method so `sam build` transpiles TypeScript. Without it, SAM
-    ships the `.ts` source, which only works for plain JavaScript:
+    `template.yaml`:
 
     ```yaml
-    DurableFunction:
-      Type: AWS::Serverless::Function
-      # Properties as above
-      Metadata:
-        BuildMethod: esbuild
-        BuildProperties:
-          Format: cjs
-          Target: node22
-          EntryPoints:
-            - index.ts
+    AWSTemplateFormatVersion: '2010-09-09'
+    Transform: AWS::Serverless-2016-10-31
+
+    Resources:
+      DurableFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+          Runtime: nodejs22.x
+          Handler: index.handler
+          CodeUri: ./src
+          DurableConfig:
+            ExecutionTimeout: 3600
+            RetentionPeriodInDays: 7
+          Policies:
+            - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          AutoPublishAlias: prod
+
+    Outputs:
+      AliasArn:
+        Value: !Ref DurableFunction.Alias
     ```
 
-=== "Python"
+    Deploy:
 
-    No build method is required. `sam build` installs dependencies from
-    `requirements.txt` and packages the source.
+    ```console
+    sam build
+    sam deploy --guided
+    ```
 
-=== "Java"
+    `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
+    invocation requires.
 
-    `sam build` builds with Maven or Gradle from your `pom.xml` or `build.gradle`.
+    `sam build` prepares your handler before packaging. What it needs depends on the
+    language:
 
-=== "C#"
+    === "TypeScript"
 
-    `sam build` builds with the .NET CLI.
+        Add an esbuild build method so `sam build` transpiles TypeScript. Without it, SAM
+        ships the `.ts` source, which only works for plain JavaScript:
+
+        ```yaml
+        DurableFunction:
+          Type: AWS::Serverless::Function
+          # Properties as above
+          Metadata:
+            BuildMethod: esbuild
+            BuildProperties:
+              Format: cjs
+              Target: node22
+              EntryPoints:
+                - index.ts
+        ```
+
+    === "Python"
+
+        No build method is required. `sam build` installs dependencies from
+        `requirements.txt` and packages the source.
+
+    === "Java"
+
+        `sam build` builds with Maven or Gradle from your `pom.xml` or `build.gradle`.
+
+    === "C#"
+
+        `sam build` builds with the .NET CLI.
+
+=== "CDK"
+
+    ```typescript
+    import * as cdk from 'aws-cdk-lib';
+    import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+    export class DurableFunctionStack extends cdk.Stack {
+      constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const fn = new lambda.Function(this, 'DurableFunction', {
+          runtime: lambda.Runtime.NODEJS_22_X,
+          handler: 'index.handler',
+          code: lambda.Code.fromAsset('lambda'),
+          durableConfig: {
+            executionTimeout: cdk.Duration.hours(1),
+            retentionPeriod: cdk.Duration.days(7),
+          },
+        });
+
+        // CDK adds the checkpoint permissions automatically when durableConfig is set.
+        const alias = new lambda.Alias(this, 'ProdAlias', {
+          aliasName: 'prod',
+          version: fn.currentVersion,
+        });
+
+        new cdk.CfnOutput(this, 'AliasArn', { value: alias.functionArn });
+      }
+    }
+    ```
+
+    Deploy:
+
+    ```console
+    cdk deploy
+    ```
 
 You can also use CloudFormation directly (`AWS::Lambda::Function` with a `DurableConfig`
 property). For durable invokes, callbacks, multi-environment stages, and log-group

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -48,7 +48,9 @@ full workflow.
     configured with credentials. Verify with `aws sts get-caller-identity`.
 - A language runtime (see the tabs below).
 - The [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) (1.153.1
-    or later), used throughout this guide to scaffold, test, and deploy. The
+    or later), used throughout this guide to scaffold, test, and deploy. Version 1.153.1
+    is the minimum that recognizes the `DurableConfig` property. Earlier versions fail at
+    `sam validate` and `sam build` with "property DurableConfig not defined". The
     [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or later) is recommended once you
     productionize the surrounding infrastructure. Direct AWS CLI access also works.
 
@@ -119,6 +121,13 @@ same replay-and-checkpoint loop the Lambda service uses, so local behavior match
 cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
 `DurableFunctionTestRunner`.
 
+The runner ships in a separate, dev-only testing package. Install it before you write
+tests (see [Authoring tests](../testing/authoring.md) for the package name for each
+language). In TypeScript the testing package's peer range can lag the runtime SDK, so if
+`npm install --save-dev @aws/durable-execution-sdk-js-testing` reports an `ERESOLVE`
+error, pin the runtime SDK to a version the peer range allows (for example
+`npm install @aws/durable-execution-sdk-js@2.1.0`).
+
 A minimal test creates a runner with your handler, runs it, and asserts on the result:
 
 === "TypeScript"
@@ -144,6 +153,10 @@ A minimal test creates a runner with your handler, runs it, and asserts on the r
     ```csharp
     --8<-- "examples/csharp/testing/authoring/minimal-test.cs"
     ```
+
+To drive an input-based handler, pass an event to the runner. In TypeScript this is
+`run({ payload: { ... } })`; see [Authoring tests](../testing/authoring.md) for the form
+each language uses.
 
 ## 3. Run Tests
 
@@ -236,6 +249,22 @@ in production.
 
     `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
     invocation requires.
+
+    For a TypeScript handler, add an esbuild build method so `sam build` transpiles it
+    (the snippet above ships the handler as-is, which only works for plain JavaScript):
+
+    ```yaml
+    DurableFunction:
+      Type: AWS::Serverless::Function
+      # Properties as above
+      Metadata:
+        BuildMethod: esbuild
+        BuildProperties:
+          Format: cjs
+          Target: node22
+          EntryPoints:
+            - index.ts
+    ```
 
 === "CDK (productionize)"
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -351,7 +351,7 @@ in production.
 
         `sam build` builds with the .NET CLI.
 
-=== "CDK (productionize)"
+=== "CDK"
 
     ```typescript
     import * as cdk from 'aws-cdk-lib';

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -17,15 +17,15 @@ the deployed function to validate packaging and runtime configuration.
 flowchart LR
     subgraph dev["Development (Local)"]
         direction LR
-        A["Write Function"]
-        B["Write Tests"]
-        C["Run Tests"]
+        A["1. Write Function"]
+        B["2. Write Tests"]
+        C["3. Run Tests"]
     end
 
     subgraph prod["Production (AWS)"]
         direction LR
-        D["Deploy"]
-        E["Test in Cloud"]
+        D["4. Deploy"]
+        E["5. Test in Cloud"]
     end
 
     A --> B --> C --> D --> E
@@ -47,7 +47,7 @@ full workflow.
     (1.153.1 or later), the [AWS CDK](https://docs.aws.amazon.com/cdk/) (2.237.1 or
     later), or direct AWS CLI access.
 
-## Write Function
+## 1. Write Function
 
 Write your durable function handler and add the SDK to your project. Bundle the SDK with
 your function code so you control the exact version, rather than relying on the Lambda
@@ -94,7 +94,7 @@ in each language, see the
     dotnet add package Amazon.Lambda.DurableExecution
     ```
 
-## Write Tests
+## 2. Write Tests
 
 Drive your handler with the testing SDK. The runner executes the handler through the
 same replay-and-checkpoint loop the Lambda service uses, so local behavior matches the
@@ -127,7 +127,7 @@ A minimal test creates a runner with your handler, runs it, and asserts on the r
     --8<-- "examples/csharp/testing/authoring/minimal-test.cs"
     ```
 
-## Run Tests
+## 3. Run Tests
 
 Run the suite with your language's test runner:
 
@@ -160,7 +160,7 @@ replay behavior. The [Testing](../testing/index.md) section covers installing th
 SDK, [authoring tests](../testing/authoring.md), [assertions](../testing/assertions.md),
 and [workflow patterns](../testing/workflow-patterns.md).
 
-## Deploy
+## 4. Deploy
 
 You can only set the `DurableConfig` at function creation time, not on a later update.
 Every durable function needs three things, whichever tool you deploy with:
@@ -258,7 +258,7 @@ property). For durable invokes, callbacks, multi-environment stages, and log-gro
 management, see the deployment guidance in the
 [Kiro Power](#agentic-development-with-kiro) below.
 
-## Test in Cloud
+## 5. Test in Cloud
 
 After deploying, validate using Lambda in the cloud.
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -174,8 +174,8 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-For anything beyond a first experiment, we recommend you deploy with SAM or CDK so your function
-configuration, IAM role, version, and alias live in source control. Tune `DurableConfig`
+For anything beyond a first experiment, we recommend you deploy with SAM or CDK whilst storing your function
+configuration, IAM role, version, alias and any related infrastructure in source control. This allows you to iterate quickly whilst reducing the additional work you'll have to do to take your work to production. Tune `DurableConfig`
 per environment: short timeouts and retention in development, longer values in
 production.
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -51,7 +51,10 @@ full workflow.
 
 Write your durable function handler and add the SDK to your project. Bundle the SDK with
 your function code so you control the exact version, rather than relying on the Lambda
-runtime-provided copy. The Lambda runtime-provided SDK version updates lag behind our aws-durable-execution-sdk-\* package updates, it can unclear what version of the SDK the runtime has and what features/bug-fixes are present. For the full handler code in each language, see the
+runtime-provided copy. The runtime-provided SDK lags behind the
+`aws-durable-execution-sdk-*` package releases, so it can be unclear which SDK version
+the runtime has and which features and bug fixes are present. For the full handler code
+in each language, see the
 [Quickstart](quickstart.md).
 
 === "TypeScript"
@@ -159,11 +162,12 @@ and [workflow patterns](../testing/workflow-patterns.md).
 
 ## Deploy
 
-You can only set the DurableConfig at function creation time, not at a later update. Every durable function needs three things, whichever tool you
-deploy with:
+You can only set the `DurableConfig` at function creation time, not on a later update.
+Every durable function needs three things, whichever tool you deploy with:
 
 1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
-    `RetentionPeriodInDays` is optional). See the https://docs.aws.amazon.com/lambda/latest/dg/durable-configuration.html.
+    `RetentionPeriodInDays` is optional). See the
+    [durable configuration reference](https://docs.aws.amazon.com/lambda/latest/dg/durable-configuration.html).
 1. The
     [AWSLambdaBasicDurableExecutionRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)
     managed policy on the execution role, which grants the checkpoint permissions.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -13,7 +13,7 @@ If you just want to deploy your first function with the AWS CLI, start with the
 
 ## Development workflow
 
-You develop durable functions in a tight inner loop: write the function, write tests,
+You develop durable functions in a tight local loop: write the function, write tests,
 and run them locally before you deploy. Once deployed, you run the same tests against
 the deployed function to validate packaging and runtime configuration.
 
@@ -273,7 +273,7 @@ timeouts and retention in development, longer values in production.
     cdk deploy
     ```
 
-You can also use CloudFormation (`AWS::Lambda::Function` with a `DurableConfig`
+You can also use CloudFormation directly (`AWS::Lambda::Function` with a `DurableConfig`
 property). For durable invokes, callbacks, multi-environment stages, and log-group
 management, see the deployment guidance in the
 [Kiro Power](#agentic-development-with-kiro) below.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -122,11 +122,41 @@ cloud. TypeScript, Java, and C# ship a `LocalDurableTestRunner`; Python uses
 `DurableFunctionTestRunner`.
 
 The runner ships in a separate, dev-only testing package. Install it before you write
-tests (see [Authoring tests](../testing/authoring.md) for the package name for each
-language). In TypeScript the testing package's peer range can lag the runtime SDK, so if
-`npm install --save-dev @aws/durable-execution-sdk-js-testing` reports an `ERESOLVE`
-error, pin the runtime SDK to a version the peer range allows (for example
-`npm install @aws/durable-execution-sdk-js@2.1.0`).
+tests (see [Authoring tests](../testing/authoring.md) for the full testing workflow):
+
+=== "TypeScript"
+
+    ```console
+    npm install --save-dev @aws/durable-execution-sdk-js-testing
+    ```
+
+    The testing package's peer range can lag the runtime SDK. If `npm install` reports an
+    `ERESOLVE` error, pin the runtime SDK to a version the peer range allows (for example
+    `npm install @aws/durable-execution-sdk-js@2.1.0`).
+
+=== "Python"
+
+    ```console
+    pip install aws-durable-execution-sdk-python-testing
+    ```
+
+=== "Java"
+
+    Add the testing dependency to your `pom.xml` with `test` scope:
+
+    ```xml
+    <dependency>
+        <groupId>software.amazon.lambda</groupId>
+        <artifactId>aws-durable-execution-sdk-java-testing</artifactId>
+        <scope>test</scope>
+    </dependency>
+    ```
+
+=== "C#"
+
+    ```console
+    dotnet add package Amazon.Lambda.DurableExecution.Testing
+    ```
 
 A minimal test creates a runner with your handler, runs it, and asserts on the result:
 
@@ -154,9 +184,31 @@ A minimal test creates a runner with your handler, runs it, and asserts on the r
     --8<-- "examples/csharp/testing/authoring/minimal-test.cs"
     ```
 
-To drive an input-based handler, pass an event to the runner. In TypeScript this is
-`run({ payload: { ... } })`; see [Authoring tests](../testing/authoring.md) for the form
-each language uses.
+To drive an input-based handler, pass an event to the runner:
+
+=== "TypeScript"
+
+    ```typescript
+    await runner.run({ payload: { orderId: "A-1" } });
+    ```
+
+=== "Python"
+
+    ```python
+    runner.run(input='{"orderId": "A-1"}')
+    ```
+
+=== "Java"
+
+    ```java
+    runner.runUntilComplete(input);
+    ```
+
+=== "C#"
+
+    ```csharp
+    await runner.RunAsync(input);
+    ```
 
 ## 3. Run Tests
 
@@ -250,21 +302,39 @@ in production.
     `AutoPublishAlias` gives you the qualified ARN (the `prod` alias) that durable
     invocation requires.
 
-    For a TypeScript handler, add an esbuild build method so `sam build` transpiles it
-    (the snippet above ships the handler as-is, which only works for plain JavaScript):
+    `sam build` prepares your handler before packaging. What it needs depends on the
+    language:
 
-    ```yaml
-    DurableFunction:
-      Type: AWS::Serverless::Function
-      # Properties as above
-      Metadata:
-        BuildMethod: esbuild
-        BuildProperties:
-          Format: cjs
-          Target: node22
-          EntryPoints:
-            - index.ts
-    ```
+    === "TypeScript"
+
+        Add an esbuild build method so `sam build` transpiles TypeScript. Without it, SAM
+        ships the `.ts` source, which only works for plain JavaScript:
+
+        ```yaml
+        DurableFunction:
+          Type: AWS::Serverless::Function
+          # Properties as above
+          Metadata:
+            BuildMethod: esbuild
+            BuildProperties:
+              Format: cjs
+              Target: node22
+              EntryPoints:
+                - index.ts
+        ```
+
+    === "Python"
+
+        No build method is required. `sam build` installs dependencies from
+        `requirements.txt` and packages the source.
+
+    === "Java"
+
+        `sam build` builds with Maven or Gradle from your `pom.xml` or `build.gradle`.
+
+    === "C#"
+
+        `sam build` builds with the .NET CLI.
 
 === "CDK (productionize)"
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -51,9 +51,9 @@ full workflow.
 
 Write your durable function handler and add the SDK to your project. Bundle the SDK with
 your function code so you control the exact version, rather than relying on the Lambda
-runtime-provided copy. The runtime-provided SDK lags behind the
-`aws-durable-execution-sdk-*` package releases, so it can be unclear which SDK version
-the runtime has and which features and bug fixes are present. For the full handler code
+runtime-provided copy. The Lambda runtime-provided SDK lags behind the public
+`aws-durable-execution-sdk-*` version releases on public package indices (e.g. NPM, PyPI, Maven, Nuget, ...). It can be unclear which SDK version
+the runtime provides, which features or bug fixes are present. For the full handler code
 in each language, see the
 [Quickstart](quickstart.md).
 
@@ -285,7 +285,7 @@ the fastest way to write correct durable functions with an agent, because it fro
 the determinism rules that are easy to get wrong.
 
 Install it from [kiro.dev/powers](https://kiro.dev/powers) or from your IDE, then
-describe what you want to build:
+build workflows from natural language prompts:
 
 ```
 Help me create a durable Lambda function that processes orders with retries
@@ -296,15 +296,10 @@ strategies, error handling, tests with the local runner, and deployment. Mention
 keywords such as `durable`, `workflow`, `saga`, `agentic`, `human-in-the-loop`, or
 `callback` activates the Power automatically.
 
-Durable functions are themselves a strong fit for **agentic** workloads: a GenAI loop
-that calls tools, waits on human approval, and runs for hours or days survives
-interruption and resumes from the last checkpoint. The Power includes patterns for
-GenAI agent loops and human-in-the-loop approvals.
-
 If you use another AI assistant, the same guidance is available as Markdown steering
 files in the
 [aws-lambda-durable-functions-power](https://github.com/aws/aws-durable-execution-docs/tree/main/aws-lambda-durable-functions-power)
-directory of this repository — load them as context to get the same replay-model and
+directory of this repository. You can load these files as context to get the same replay-model and
 deployment rules.
 
 ## Next steps

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -5,8 +5,8 @@ project, writing and testing the function locally, and deploying it. It uses the
 [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/) for the local
 development loop (`sam init` to start, `sam local invoke` to run, and `sam deploy` to
 ship) and the [AWS CDK](https://docs.aws.amazon.com/cdk/) when you productionize the
-surrounding infrastructure. It also covers the AI agent tooling (the Agent Toolkit for
-AWS) the team ships for building durable functions.
+surrounding infrastructure. It also covers the AI agent tooling (the [Agent Toolkit for
+AWS](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/what-is-agent-toolkit.html)) the team ships for building durable functions.
 
 If you just want to deploy your first function with the AWS CLI, start with the
 [Quickstart](quickstart.md). This page is about the day-to-day workflow after that.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -50,8 +50,8 @@ full workflow.
 ## Write Function
 
 Write your durable function handler and add the SDK to your project. Bundle the SDK with
-your function code so you control the exact version, rather than relying on the Lambda 
-runtime-provided copy. The Lambda runtime-provided SDK version updates lag behind our aws-durable-execution-sdk-* package updates, it can unclear what version of the SDK the runtime has and what features/bug-fixes are present. For the full handler code in each language, see the
+your function code so you control the exact version, rather than relying on the Lambda
+runtime-provided copy. The Lambda runtime-provided SDK version updates lag behind our aws-durable-execution-sdk-\* package updates, it can unclear what version of the SDK the runtime has and what features/bug-fixes are present. For the full handler code in each language, see the
 [Quickstart](quickstart.md).
 
 === "TypeScript"
@@ -128,13 +128,29 @@ A minimal test creates a runner with your handler, runs it, and asserts on the r
 
 Run the suite with your language's test runner:
 
-```console
-# TypeScript / Jest
-npm test
+=== "TypeScript"
 
-# Python / pytest
-pytest
-```
+    ```console
+    npm test
+    ```
+
+=== "Python"
+
+    ```console
+    pytest
+    ```
+
+=== "Java"
+
+    ```console
+    mvn test
+    ```
+
+=== "C#"
+
+    ```console
+    dotnet test
+    ```
 
 Get operations by name (never by index) and invoke the runner more than once to assert
 replay behavior. The [Testing](../testing/index.md) section covers installing the testing

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -192,12 +192,13 @@ Every durable function needs three things, whichever tool you deploy with:
 1. A qualified ARN (a published version or an alias) to invoke. Durable execution is not
     supported on an unqualified function name.
 
-Deploy with SAM while you iterate: it keeps your function configuration, IAM role,
-version, and alias in source control with minimal ceremony, and pairs with the
-`sam local invoke` / `sam deploy` loop. When you productionize — composing the function
-with the rest of your infrastructure (queues, tables, alarms, multi-environment stages) —
-AWS CDK gives you a typed, programmable app. Tune `DurableConfig` per environment: short
-timeouts and retention in development, longer values in production.
+Deploy with SAM while you iterate: it declares your function configuration, IAM role,
+version, and alias in a single `template.yaml` — one place you can check into source
+control — and pairs with the `sam local invoke` / `sam deploy` loop. When you
+productionize — composing the function with the rest of your infrastructure (queues,
+tables, alarms, multi-environment stages) — AWS CDK gives you a typed, programmable app.
+Tune `DurableConfig` per environment: short timeouts and retention in development, longer
+values in production.
 
 === "SAM (iterate)"
 

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -143,8 +143,7 @@ Every durable function needs three things, whichever tool you deploy with:
 
 1. A `DurableConfig` on the function (`ExecutionTimeout` is required;
     `RetentionPeriodInDays` is optional). See the
-    [configuration reference](../sdk-reference/configuration/index.md) for the valid
-    ranges and defaults.
+    [configuration reference](../sdk-reference/configuration/index.md).
 1. The
     [AWSLambdaBasicDurableExecutionRolePolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)
     managed policy on the execution role, which grants the checkpoint permissions.


### PR DESCRIPTION
## What

Expands `docs/getting-started/development-environment.md` from a placeholder (a single workflow diagram) into a full development-environment guide, per #111. Sections:

- **Development workflow** — keeps the existing inner-loop diagram, with context.
- **Prerequisites** — AWS CLI, language runtime, and a deploy tool (SAM CLI / CDK / CLI), with the minimum versions the team documents.
- **Install the SDK** — per-language tabs (TypeScript / Python / Java / C#) matching the Quickstart package names and runtimes.
- **Write and test locally** — the local runner (`LocalDurableTestRunner` / `DurableFunctionTestRunner`), linking into the Testing section rather than duplicating it.
- **Configure your function** — the three requirements (`DurableConfig`, `AWSLambdaBasicDurableExecutionRolePolicy`, qualified ARN) with a link to the configuration reference.
- **Deploy with infrastructure as code** — **SAM and CDK** examples (the core ask), plus a CloudFormation note.
- **Test against the cloud** — Cloud Runner + SAM CLI (`sam local invoke` / `sam remote invoke`).
- **Agentic development with Kiro** — documents the team's **Kiro Power** (`aws-lambda-durable-functions-power`), how to install/activate it, and the steering files for other AI assistants; notes why durable functions suit agentic workloads.

## Grounding

Content is grounded in existing repo sources — the Quickstart, the Testing pages, the new configuration reference (#229), and the `aws-lambda-durable-functions-power` steering pack (`README.md`/`POWER.md`/`deployment-iac.md`/`getting-started.md`) — not invented. No SDK behavior is asserted beyond what those sources state.

## Quality

`mdformat --check` and `codespell` pass on the file, and it contains no hidden characters — so it satisfies the PR quality gate added in #230. Links point to existing pages.

Closes #111