### PR TITLE
docs: add OpenTelemetry plugin page under Observability

### DIFF
--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -278,7 +278,7 @@ header the plugin reads, and grant the function's role the
     MyFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Runtime: java21
+        Runtime: java25
         Handler: com.example.ExampleHandler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-java-layer>:<version>

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -60,9 +60,11 @@ export the root span. You register exactly one of them.
 `ExecutionOtelPlugin` opens a synthetic `Workflow` span as the trace root. Every
 invocation span and operation span nests under it. The plugin exports the
 `Workflow` span only when the execution reaches a terminal status, so an
-execution that is still running does not leave a dangling root span. Choose this
-plugin when you want one unified trace per execution, with the workflow as the
-logical root.
+execution that is still running does not leave a dangling root span, but you also
+cannot watch the trace in progress, and a span held open for hours can exceed the
+ingestion limits of some observability platforms. Choose this plugin for short
+executions, or when you want one unified trace per execution with the workflow as
+the logical root.
 
 === "TypeScript"
 
@@ -107,8 +109,13 @@ which invocation ran each operation even though the operations root under the
 execution ARN and ended only at the terminal invocation. The invocation span is
 not a child of that `Workflow` span. Each invocation span roots its own operation
 and attempt spans, and those spans carry a link to the `Workflow` span for
-execution-scoped correlation. Choose this plugin when you want per-invocation
-traces that still correlate to one workflow.
+execution-scoped correlation.
+
+The plugin exports each invocation span as that invocation ends. A Lambda
+invocation lasts at most 15 minutes, so spans stay within platform limits and
+appear as the execution runs, which renders reliably across most platforms.
+Choose this plugin for long-running executions, or when you want per-invocation
+traces that still correlate to one workflow and to view an execution in progress.
 
 === "TypeScript"
 
@@ -155,21 +162,9 @@ links.
 
 ### Choosing a plugin
 
-Choose based on how long your executions run and where you send traces.
-
-`ExecutionOtelPlugin` exports the `Workflow` root span only when the execution
-reaches a terminal status. For a short execution this gives one clean trace. For
-a long-running execution, the root span stays open until the execution finishes,
-so you cannot watch the trace in progress, and a span open for hours can exceed
-the ingestion limits of some observability platforms.
-
-`InvocationOtelPlugin` exports each invocation span as that invocation ends. A
-Lambda invocation lasts at most 15 minutes, so spans stay within platform limits
-and appear as the execution runs. This renders reliably across most platforms
-and shows how operations are processed across invocations. Prefer it for
-long-running executions, or when you want to view an execution in progress.
-
-For both plugins, your observability platform's quotas and limits apply.
+The `ExecutionOtelPlugin` and `InvocationOtelPlugin` sections above cover when to
+choose each. This table summarizes the differences. For both plugins, your
+observability platform's quotas and limits apply.
 
 | Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
 | ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -1,0 +1,415 @@
+# OpenTelemetry
+
+The OpenTelemetry plugin instruments a durable execution and emits distributed
+traces to any OTLP backend, such as Amazon CloudWatch or AWS X-Ray. It builds on
+the [plugin interface](plugins.md): you register it in your handler
+configuration, and it opens spans at the invocation, operation, and attempt
+boundaries as the execution runs.
+
+A durable execution runs across many Lambda invocations. The plugin derives
+deterministic trace and span IDs from the execution ARN, and from the X-Ray
+trace header when one is present, so the spans from every invocation join a
+single trace. Without deterministic IDs, each invocation would produce its own
+disconnected trace.
+
+!!! note "Experimental feature"
+
+    The OpenTelemetry plugin is experimental and may change in a future
+    release. It is not recommended for production workloads yet. Feedback is
+    welcome through our
+    [GitHub Discussion](https://github.com/aws/aws-durable-execution-docs/discussions/206).
+
+!!! note "C# support"
+
+    The .NET plugin ships when the AWS Lambda Durable Execution SDK for C#
+    becomes generally available. Until then, this page covers TypeScript,
+    Python, and Java.
+
+## Install the plugin
+
+=== "TypeScript"
+
+    ```bash
+    npm install @aws/durable-execution-sdk-js-otel
+    ```
+
+    When the plugin creates its own tracer provider (the default), install the
+    OpenTelemetry packages it configures:
+
+    ```bash
+    npm install @opentelemetry/sdk-trace-node \
+                @opentelemetry/exporter-trace-otlp-http \
+                @opentelemetry/propagator-aws-xray \
+                @opentelemetry/instrumentation-http \
+                @opentelemetry/resources
+    ```
+
+    When you use the ADOT layer's global tracer provider, the layer supplies
+    these packages and you only need `@opentelemetry/api`.
+
+=== "Python"
+
+    ```bash
+    pip install aws-durable-execution-sdk-python-otel
+    ```
+
+    The package depends on `opentelemetry-api`, `opentelemetry-sdk`, and
+    `opentelemetry-exporter-otlp`.
+
+=== "Java"
+
+    ```xml
+    <dependency>
+        <groupId>software.amazon.lambda.durable</groupId>
+        <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
+        <version>${durable.sdk.version}</version>
+    </dependency>
+    ```
+
+    Add the OpenTelemetry SDK and an exporter:
+
+    ```xml
+    <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-sdk</artifactId>
+        <version>1.63.0</version>
+    </dependency>
+    <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-exporter-otlp</artifactId>
+        <version>1.63.0</version>
+    </dependency>
+    ```
+
+## Register the plugin
+
+Add the plugin to your handler configuration. The SDK calls it as the execution
+runs, and you write no tracing code in your handler.
+
+=== "TypeScript"
+
+    ```typescript
+    import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+    import { InvocationOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+    export const handler = withDurableExecution(
+      async (event, context) => {
+        return await context.step("process", async () => "done");
+      },
+      { plugins: [new InvocationOtelPlugin()] },
+    );
+    ```
+
+    The package exports two plugins, `InvocationOtelPlugin` and
+    `ExecutionOtelPlugin`. They register the same way. See
+    [Trace structure](#trace-structure) for how they differ.
+
+=== "Python"
+
+    ```python
+    from aws_durable_execution_sdk_python import DurableContext, durable_execution
+    from aws_durable_execution_sdk_python_otel import InvocationOtelPlugin
+
+
+    @durable_execution(plugins=[InvocationOtelPlugin()])
+    def handler(event: dict, context: DurableContext) -> str:
+        return context.step(lambda ctx: "done", name="process")
+    ```
+
+    The package exports both `InvocationOtelPlugin` and `ExecutionOtelPlugin`.
+    See [Trace structure](#trace-structure) for how they differ.
+
+=== "Java"
+
+    The plugin constructor takes the tracer provider builder. Add a span
+    exporter to it, and the plugin sets the deterministic ID generator.
+
+    ```java
+    import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+    import io.opentelemetry.sdk.trace.SdkTracerProvider;
+    import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+    import software.amazon.lambda.durable.DurableConfig;
+    import software.amazon.lambda.durable.DurableContext;
+    import software.amazon.lambda.durable.DurableHandler;
+    import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
+
+    public class ExampleHandler extends DurableHandler<Object, String> {
+        @Override
+        protected DurableConfig createConfiguration() {
+            var plugin = new InvocationOtelPlugin(
+                    SdkTracerProvider.builder()
+                            .addSpanProcessor(
+                                    SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
+            return DurableConfig.builder().withPlugins(plugin).build();
+        }
+
+        @Override
+        protected String handleRequest(Object event, DurableContext context) {
+            return context.step("process", String.class, stepCtx -> "done");
+        }
+    }
+    ```
+
+## Deploy with a Lambda layer
+
+The plugin produces spans, and a collector transports them from your function to
+your backend. Attach a Lambda layer that runs the collector, enable X-Ray active
+tracing so the runtime populates the `_X_AMZN_TRACE_ID` header the plugin reads,
+and grant the function's role X-Ray write permissions with the
+`AWSXRayDaemonWriteAccess` managed policy.
+
+Enabling active tracing matters for trace continuity. Without it,
+`_X_AMZN_TRACE_ID` is unset and the plugin falls back to the execution ARN for
+the trace ID. The traces still form, but resumed invocations can fragment across
+separate trace IDs.
+
+=== "TypeScript"
+
+    Use either the AWS Distro for OpenTelemetry (ADOT) layer or the smaller
+    OpenTelemetry community collector layer.
+
+    With the ADOT layer, set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`
+    and construct the plugin with `useDefaultTracerProvider: true` so it uses the
+    layer's global provider:
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: nodejs22.x
+        Handler: index.handler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:615299751070:layer:AWSOpenTelemetryDistroJs:7
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+    With the community collector layer, do not set `AWS_LAMBDA_EXEC_WRAPPER`. The
+    plugin creates its own provider and exports to the collector on
+    `localhost:4318`. Include a `collector.yaml` in your bundle and set
+    `OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path.
+
+=== "Python"
+
+    Add the ADOT layer and set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`.
+    Find the current layer ARN for your region and architecture in the
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python).
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: python3.12
+        Handler: index.handler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:aws-otel-python-amd64-ver-<version>
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+=== "Java"
+
+    Add the ADOT layer, then enable active tracing and X-Ray permissions. Do not
+    set `AWS_LAMBDA_EXEC_WRAPPER`. The wrapper attaches the auto-instrumentation
+    agent, which creates a second tracer provider and splits the trace into
+    disconnected service nodes on the X-Ray map.
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: java17
+        Handler: com.example.ExampleHandler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-amd64-ver-1-32-0:6
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+## Trace structure
+
+The plugin opens three levels of spans. An invocation span covers one Lambda
+invocation of the execution. Operation spans nest under it, one per durable
+operation such as a step, wait, or child invoke. Attempt spans nest under a step
+or wait-for-condition operation, one per try, so retries appear as sibling
+spans.
+
+Because trace and span IDs derive from the execution ARN and each operation's ID,
+an operation that starts in one invocation and completes in a later one links
+back to its original span. All invocations of one execution share a single trace
+ID.
+
+Both `InvocationOtelPlugin` and `ExecutionOtelPlugin` correlate a whole execution
+into one trace. They differ in the trace root.
+
+=== "TypeScript"
+
+    `ExecutionOtelPlugin` opens a synthetic `Workflow` span as the trace root and
+    exports it only when the execution reaches a terminal status, so incomplete
+    executions do not leave dangling roots. `InvocationOtelPlugin` roots the trace
+    at each invocation span, and with the community collector it also opens the
+    `Workflow` root. Configure both with the shared `OtelPluginConfig`.
+
+    ```typescript
+    import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+    const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+    ```
+
+=== "Python"
+
+    `ExecutionOtelPlugin` opens a `Workflow` root span and takes an
+    `OtelPluginConfig`. `InvocationOtelPlugin` roots the trace at the invocation
+    span and takes keyword arguments.
+
+    ```python
+    from aws_durable_execution_sdk_python_otel import (
+        ExecutionOtelPlugin,
+        OtelPluginConfig,
+    )
+
+    plugin = ExecutionOtelPlugin(OtelPluginConfig(use_default_tracer_provider=True))
+    ```
+
+=== "Java"
+
+    `InvocationOtelPlugin` opens a `Workflow` root span whose name you can set
+    through the constructor. The service name on the exported spans' resource is
+    `invocation`.
+
+The spans carry these attributes.
+
+| Span       | Attributes                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Invocation | `durable.execution.arn`, `durable.invocation.status`, `durable.invocation.first`                                                                             |
+| Operation  | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status` |
+| Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
+
+`durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
+or `CALLBACK`. The plugin also attaches standard FaaS resource attributes, such
+as the function name and region, from the Lambda environment.
+
+=== "Java"
+
+    Attempt spans are not opened for `CONTEXT` operations, so a child context
+    contributes an operation span but no attempt span.
+
+## Configuration
+
+=== "TypeScript"
+
+    Pass an `OtelPluginConfig` to either plugin.
+
+    - **tracerProvider** A provider to use as-is. Takes precedence over the other
+        provider options.
+    - **useDefaultTracerProvider** Use the globally registered provider, such as
+        the ADOT layer's. Defaults to `false`.
+    - **contextExtractor** Extracts upstream trace context. Defaults to
+        `xRayContextExtractor`. Use `w3cClientContextExtractor` for W3C
+        `traceparent` propagation.
+    - **exporterConfig** OTLP `endpoint` and `headers`, used only when the plugin
+        creates its own provider.
+    - **propagators** Replaces the default `[AWSXRay, W3CTraceContext]`
+        propagators.
+    - **enableHttpInstrumentation** Registers HTTP instrumentation. Defaults to
+        `true`.
+    - **instrumentationName** Instrumentation scope name. Defaults to
+        `aws-durable-execution-sdk-js`.
+    - **workflowSpanName** Name of the `Workflow` root span. Defaults to
+        `Workflow`.
+
+    Control sampling with the `OTEL_DURABLE_SAMPLING_RATIO` environment variable,
+    from `0.0` to `1.0`. All invocations of one execution are sampled or dropped
+    together.
+
+=== "Python"
+
+    `InvocationOtelPlugin` takes keyword arguments.
+
+    - **trace_provider** A tracer provider to use. Defaults to the globally
+        configured provider.
+    - **context_extractor** Defaults to `xray_context_extractor`. Use
+        `w3c_client_context_extractor` for W3C `traceparent` propagation.
+    - **instrument_name** Instrumentation scope name. Defaults to
+        `aws-durable-execution-sdk-python`.
+    - **enrich_logger** Installs a root-logger filter that stamps trace context
+        onto log records. Defaults to `True`.
+
+    `ExecutionOtelPlugin` takes an `OtelPluginConfig` dataclass with the same
+    provider, extractor, exporter, and `workflow_span_name` options as the
+    TypeScript config.
+
+    Control sampling through the ADOT layer with `OTEL_TRACES_SAMPLER` and
+    `OTEL_TRACES_SAMPLER_ARG`.
+
+=== "Java"
+
+    The constructor takes the tracer provider builder and three optional
+    arguments.
+
+    ```java
+    new InvocationOtelPlugin(tracerProviderBuilder);
+    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
+    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
+    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName);
+    ```
+
+    - **contextExtractor** Defaults to `XRayContextExtractor`.
+    - **enableMdc** Injects `traceId`, `spanId`, and `traceSampled` into the SLF4J
+        MDC. Defaults to `true`.
+    - **workflowSpanName** Name of the `Workflow` root span. Defaults to
+        `Workflow`.
+
+## Correlate logs with traces
+
+The plugin stamps the active trace and span IDs onto your log records, so a log
+line in CloudWatch links to the span that emitted it. See [Logging](logging.md)
+for the SDK logger.
+
+=== "TypeScript"
+
+    The plugin enriches log context with `traceId` and `spanId` through the
+    plugin log hook described in [Logging from a plugin](plugins.md#logging-from-a-plugin).
+
+=== "Python"
+
+    With `enrich_logger=True` (the default), the plugin installs a filter on the
+    root logger that adds `traceId`, `spanId`, and `otelTraceSampled` to every
+    record when a span is active.
+
+=== "Java"
+
+    With `enableMdc=true` (the default), the plugin puts `traceId`, `spanId`, and
+    `traceSampled` into the SLF4J MDC. Configure your logging framework to include
+    MDC fields in its output.
+
+## Verify
+
+Invoke a durable function that includes a wait or a resume, so the execution runs
+across more than one invocation. In the CloudWatch console, open Traces and
+confirm the invocation and operation spans appear under one trace ID. Check that
+your log entries carry `traceId` and `spanId` matching those spans.
+
+When you use the community collector layer, enable CloudWatch Transaction Search
+in your account for traces to appear. If no traces show up, the collector layer
+is missing or its configuration variable is unset. If traces fragment across
+several IDs, active tracing is off. If some operation spans are missing, the
+sampling ratio is below `1.0`.
+
+## See also
+
+- [Plugins](plugins.md)
+- [Logging](logging.md)
+- [Steps](../operations/step.md)

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -403,6 +403,8 @@ without first sending them to CloudWatch or X-Ray.
         `aws-durable-execution-sdk-js`.
     - **workflowSpanName** Name of the `Workflow` root span. Defaults to
         `Workflow`.
+    - **enrichLogger** Adds `traceId`, `spanId`, and `otelTraceSampled` to each
+        durable log record through `enrichLogContext()`. Defaults to `true`.
 
     Control sampling with the `OTEL_DURABLE_SAMPLING_RATIO` environment variable,
     from `0.0` to `1.0`. All invocations of one execution are sampled or dropped
@@ -463,8 +465,10 @@ for the SDK logger.
 
 === "TypeScript"
 
-    The plugin enriches log context with `traceId` and `spanId` through the
-    plugin log hook described in [Logging from a plugin](plugins.md#logging-from-a-plugin).
+    With `enrichLogger` enabled (the default), the plugin adds `traceId`,
+    `spanId`, and `otelTraceSampled` to each durable log record through the
+    `enrichLogContext()` hook described in
+    [Logging from a plugin](plugins.md#logging-from-a-plugin).
 
 === "Python"
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -71,12 +71,12 @@ disconnected trace.
     <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-sdk</artifactId>
-        <version>1.63.0</version>
+        <version>some version</version>
     </dependency>
     <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-exporter-otlp</artifactId>
-        <version>1.63.0</version>
+        <version>some version</version>
     </dependency>
     ```
 
@@ -195,7 +195,8 @@ currently visualize them.
 | ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Trace root             | Synthetic `Workflow` span                                         | Invocation span (`Workflow` root with the community collector)                   |
 | Root span export       | Only when the execution completes                                 | Each invocation span exports when that invocation ends                           |
-| In-progress visibility | None until the execution finishes                                 | Each invocation appears as it completes                                          |
+| Operation span         | Exported in its entirety, once when complete                      | May be duplicated under multiple invocations spans                               |
+| In-progress visibility | Fragmented until the execution finishes                           | Each invocation appears as it completes                                          |
 | Best for               | Short executions                                                  | Long-running executions, or watching one in progress                             |
 | Platform compatibility | A long-open root span can exceed some platforms' ingestion limits | Invocation spans stay within the 15-minute Lambda limit, so they render reliably |
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -21,9 +21,8 @@ disconnected trace.
 
 !!! note "C# support"
 
-    The .NET plugin ships when the AWS Lambda Durable Execution SDK for C#
-    becomes generally available. Until then, this page covers TypeScript,
-    Python, and Java.
+    The OpenTelemetry plugin for C# is a work in progress. Until it ships, this
+    page covers TypeScript, Python, and Java.
 
 ## Install the plugin
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -487,7 +487,7 @@ for the SDK logger.
 Invoke a durable function that includes a wait or a resume, so the execution runs
 across more than one invocation. In the CloudWatch console, open Traces and
 confirm the invocation and operation spans appear under one trace ID. Check that
-your log entries carry `traceId` and `spanId` matching those spans.
+your log entries carry `traceId`, `spanId`, and `otelTraceSampled` matching those spans.
 
 When you use the community collector layer, enable CloudWatch Transaction Search
 in your account for traces to appear. If no traces show up, the collector layer

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -452,7 +452,7 @@ without first sending them to CloudWatch or X-Ray.
     `ExecutionOtelPlugin` offers the same no-arg and builder constructors.
 
     - **contextExtractor** Defaults to `XRayContextExtractor`.
-    - **enableMdc** Injects `traceId`, `spanId`, and `traceSampled` into the SLF4J
+    - **enableMdc** Injects `traceId`, `spanId`, and `otelTraceSampled` into the SLF4J
         MDC. Defaults to `true`.
     - **workflowSpanName** Name of the `Workflow` root span. Defaults to
         `Workflow`.
@@ -479,7 +479,7 @@ for the SDK logger.
 === "Java"
 
     With `enableMdc=true` (the default), the plugin puts `traceId`, `spanId`, and
-    `traceSampled` into the SLF4J MDC. Configure your logging framework to include
+    `otelTraceSampled` into the SLF4J MDC. Configure your logging framework to include
     MDC fields in its output.
 
 ## Verify

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -32,28 +32,11 @@ disconnected trace.
     npm install @aws/durable-execution-sdk-js-otel
     ```
 
-    When a plugin creates its own tracer provider, install the OpenTelemetry
-    packages it configures:
-
-    ```bash
-    npm install @opentelemetry/sdk-trace-node \
-                @opentelemetry/exporter-trace-otlp-http \
-                @opentelemetry/propagator-aws-xray \
-                @opentelemetry/instrumentation-http \
-                @opentelemetry/resources
-    ```
-
-    When a plugin uses the ADOT layer's global tracer provider, the layer
-    supplies these packages and you only need `@opentelemetry/api`.
-
 === "Python"
 
     ```bash
     pip install aws-durable-execution-sdk-python-otel
     ```
-
-    The package depends on `opentelemetry-api`, `opentelemetry-sdk`, and
-    `opentelemetry-exporter-otlp`.
 
 === "Java"
 
@@ -62,21 +45,6 @@ disconnected trace.
         <groupId>software.amazon.lambda.durable</groupId>
         <artifactId>aws-durable-execution-sdk-java-plugin-otel</artifactId>
         <version>${durable.sdk.version}</version>
-    </dependency>
-    ```
-
-    Add the OpenTelemetry SDK and an exporter:
-
-    ```xml
-    <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-sdk</artifactId>
-        <version>some version</version>
-    </dependency>
-    <dependency>
-        <groupId>io.opentelemetry</groupId>
-        <artifactId>opentelemetry-exporter-otlp</artifactId>
-        <version>some version</version>
     </dependency>
     ```
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -159,13 +159,15 @@ into multiple spans, spanning multiple invocations. The plugin provides a Link f
 spans linking to the first such operation span. Note that Cloudwatch doesn't implement Links and doesn't
 currently visualize them.
 
+Note that for both plugins, observability platform quotas/limitations will apply.
+
 | Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
 | ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | Trace root             | Synthetic `Workflow` span                                         | Invocation span (`Workflow` root with the community collector)                   |
 | Root span export       | Only when the execution completes                                 | Each invocation span exports when that invocation ends                           |
 | Operation span         | Exported in its entirety, once when complete                      | May be duplicated under multiple invocations spans                               |
 | In-progress visibility | Fragmented until the execution finishes                           | Each invocation appears as it completes                                          |
-| Best for               | Short executions                                                  | Long-running executions, or watching one in progress                             |
+| Better for             | Short executions                                                  | Longer-running executions, or watching one in progress                           |
 | Platform compatibility | A long-open root span can exceed some platforms' ingestion limits | Invocation spans stay within the 15-minute Lambda limit, so they render reliably |
 
 ## Span structure and attributes

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -86,13 +86,14 @@ The trace you see groups every invocation of the execution under one `Workflow`
 root:
 
 ```text
-Workflow                          (root, exported on terminal status)
-├── Invocation                    (one span per Lambda invocation)
-├── Operation: fetch-data  (STEP)
-│   └── Attempt: fetch-data attempt 1
-├── Operation: cooldown    (WAIT)
-└── Operation: process     (STEP)
-    └── Attempt: process attempt 1
+Workflow                              (root, exported on terminal status)
+├── Invocation #1
+├── Invocation #2
+├── Operation: fetch-data  (STEP)      -> link to Invocation #1
+│   └── Attempt: fetch-data attempt 1  -> link to Invocation #1
+├── Operation: cooldown    (WAIT)      -> link to Invocation #2
+└── Operation: process     (STEP)      -> link to Invocation #2
+    └── Attempt: process attempt 1     -> link to Invocation #2
 ```
 
 Operation spans link to the invocation span that produced them, so you can tell
@@ -253,7 +254,7 @@ header the plugin reads, and grant the function's role the
         Runtime: python3.12
         Handler: index.handler
         Layers:
-          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:aws-otel-python-amd64-ver-<version>
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-python-layer>:<version>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
@@ -300,14 +301,6 @@ header the plugin reads, and grant the function's role the
     new ExecutionOtelPlugin();   // uses the agent's global provider
     new InvocationOtelPlugin();  // uses the agent's global provider
     ```
-
-**With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
-The plugin exports the `Workflow` span only on terminal status.
-
-**With InvocationOtelPlugin,** you get per-invocation traces that correlate to
-one `Workflow` span through links. The plugin always creates its own invocation
-span; with `useDefaultTracerProvider: true` it parents that span to the layer's
-ambient Lambda span.
 
 ## Deploy with the community collector layer
 
@@ -391,16 +384,6 @@ without first sending them to CloudWatch or X-Ray.
     var plugin = new ExecutionOtelPlugin(
             SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)));
     ```
-
-**With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
-The plugin exports the `Workflow` span only on terminal status, so intermediate
-invocations do not emit incomplete workflow spans.
-
-**With InvocationOtelPlugin,** the plugin opens the parentless `Workflow` root
-span with a deterministic ID and exports it only on terminal status. The
-invocation span is not a child of the `Workflow` span; it roots the per-invocation
-view and links to the `Workflow` span. The plugin exports each invocation span at
-the end of its Lambda invocation.
 
 ## Configuration
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -7,8 +7,8 @@ configuration, and it opens spans at the invocation, operation, and attempt
 boundaries as the execution runs.
 
 A durable execution runs across many Lambda invocations. The plugin derives
-deterministic trace and span IDs from the execution ARN, and from the
-`_X_AMZN_TRACE_ID` trace header when one is present, so the spans from every invocation join a
+deterministic trace and span IDs from the execution ARN, and from the X-Ray
+trace header when one is present, so the spans from every invocation join a
 single trace. Without deterministic IDs, each invocation would produce its own
 disconnected trace.
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -1,14 +1,14 @@
 # OpenTelemetry
 
 The OpenTelemetry plugin instruments a durable execution and emits distributed
-traces to any OTLP backend, such as Amazon CloudWatch or AWS X-Ray. It builds on
+traces to any OTLP backend, such as Amazon CloudWatch. It builds on
 the [plugin interface](plugins.md): you register it in your handler
 configuration, and it opens spans at the invocation, operation, and attempt
 boundaries as the execution runs.
 
 A durable execution runs across many Lambda invocations. The plugin derives
-deterministic trace and span IDs from the execution ARN, and from the X-Ray
-trace header when one is present, so the spans from every invocation join a
+deterministic trace and span IDs from the execution ARN, and from the
+`_X_AMZN_TRACE_ID` trace header when one is present, so the spans from every invocation join a
 single trace. Without deterministic IDs, each invocation would produce its own
 disconnected trace.
 
@@ -199,8 +199,8 @@ no attempt span, since attempt spans apply only to steps and wait-for-conditions
 
 The AWS Distro for OpenTelemetry (ADOT) Lambda layer bundles OpenTelemetry
 auto-instrumentation and a collector extension. The collector listens on
-`localhost:4318` and forwards spans to X-Ray and CloudWatch. Add the layer,
-enable X-Ray active tracing so the runtime populates the `_X_AMZN_TRACE_ID`
+`localhost:4318` and forwards spans to CloudWatch. Add the layer,
+enable active tracing so the runtime populates the `_X_AMZN_TRACE_ID`
 header the plugin reads, and grant the function's role the
 `AWSXRayDaemonWriteAccess` managed policy.
 
@@ -325,7 +325,7 @@ service:
 
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
-without first sending them to CloudWatch or X-Ray.
+without first sending them to CloudWatch.
 
 === "TypeScript"
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -325,7 +325,8 @@ service:
 
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
-without first sending them to CloudWatch.
+without first sending them to CloudWatch. Check https://github.com/open-telemetry/opentelemetry-lambda/releases
+for the most recent Collector layer releases.
 
 === "TypeScript"
 
@@ -334,7 +335,7 @@ without first sending them to CloudWatch.
 
     ```yaml
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:184161586896:layer:opentelemetry-nodejs-0_22_0:1
+      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
     Environment:
       Variables:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
@@ -354,7 +355,7 @@ without first sending them to CloudWatch.
 
     ```yaml
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>
+      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
     Environment:
       Variables:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
@@ -368,7 +369,7 @@ without first sending them to CloudWatch.
 
     ```yaml
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>
+      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
     Environment:
       Variables:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -261,11 +261,12 @@ header the plugin reads, and grant the function's role the
 
 === "Java"
 
-    Add the layer for its collector, but do not set `AWS_LAMBDA_EXEC_WRAPPER`.
-    The Java plugin always builds its own tracer provider from the builder you
-    pass, and the wrapper would attach a second, competing provider that splits
-    the trace into disconnected service nodes on the X-Ray map. Point the
-    plugin's exporter at the layer's collector on `localhost:4318`.
+    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument` to activate the ADOT
+    Java agent, and register the plugin jar as an agent extension through
+    `OTEL_JAVAAGENT_EXTENSIONS` (the path to the bundled plugin jar) so its SPI
+    installs deterministic ID generation into the agent's provider. Then
+    construct either plugin with the no-arg constructor, which reads the agent's
+    global provider.
 
     ```yaml
     MyFunction:
@@ -275,22 +276,28 @@ header the plugin reads, and grant the function's role the
         Handler: com.example.ExampleHandler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-amd64-ver-1-32-0:6
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+            OTEL_JAVAAGENT_EXTENSIONS: /opt/otel-plugin-extension.jar
         Tracing: Active
         Policies:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
     ```
 
-**With ExecutionOtelPlugin,** the plugin still opens the `Workflow` root span and
-exports it on terminal status. When it uses the ADOT layer's global provider, it
-does not open its own invocation span. It links operations to the layer's
-ambient invocation span instead.
+    ```java
+    new ExecutionOtelPlugin();   // uses the agent's global provider
+    new InvocationOtelPlugin();  // uses the agent's global provider
+    ```
 
-**With InvocationOtelPlugin,** the plugin delegates span creation to the ADOT
-layer's provider and does not open its own `Workflow` or invocation span.
-Operations attach to the layer's ambient invocation span, so you get
-per-invocation traces correlated by deterministic span IDs rather than one
-`Workflow`-rooted trace.
+**With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
+The plugin exports the `Workflow` span only on terminal status.
+
+**With InvocationOtelPlugin,** you get per-invocation traces correlated across
+invocations by deterministic span IDs. In TypeScript, this plugin can delegate
+span creation to the ADOT layer's ambient invocation span; Python and Java open
+their own spans through the layer's provider.
 
 ## Deploy with the community collector layer
 
@@ -357,9 +364,9 @@ without first sending them to X-Ray.
 
 === "Java"
 
-    Both plugins already build their own provider from the builder you pass, so
-    add an OTLP exporter pointed at `localhost:4318`. This is the same wiring
-    shown in [The two plugins](#the-two-plugins).
+    Do not set `AWS_LAMBDA_EXEC_WRAPPER`. Construct either plugin with a builder
+    that adds an OTLP exporter pointed at `localhost:4318`, so the plugin owns
+    its provider instead of reading the agent's.
 
     ```yaml
     Layers:
@@ -367,6 +374,12 @@ without first sending them to X-Ray.
     Environment:
       Variables:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```
+
+    ```java
+    var exporter = OtlpGrpcSpanExporter.getDefault();
+    var plugin = new ExecutionOtelPlugin(
+            SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)));
     ```
 
 **With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
@@ -429,15 +442,20 @@ invocations.
 
 === "Java"
 
-    Each plugin's constructor takes the tracer provider builder and three
-    optional arguments.
+    Each plugin has a no-arg constructor that uses the ADOT Java agent's global
+    provider, plus builder constructors for supplying your own provider. The
+    no-arg form requires the ADOT agent and the plugin jar registered through
+    `OTEL_JAVAAGENT_EXTENSIONS`.
 
     ```java
+    new InvocationOtelPlugin();
     new InvocationOtelPlugin(tracerProviderBuilder);
     new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
     new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
     new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName);
     ```
+
+    `ExecutionOtelPlugin` offers the same no-arg and builder constructors.
 
     - **contextExtractor** Defaults to `XRayContextExtractor`.
     - **enableMdc** Injects `traceId`, `spanId`, and `traceSampled` into the SLF4J

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -171,6 +171,30 @@ Operations that resume in a later invocation link back to the original
 operation's deterministic span ID, so a retry or a resumed wait relates to its
 first appearance.
 
+### Choosing a plugin
+
+Choose based on how long your executions run and where you send traces.
+
+`ExecutionOtelPlugin` exports the `Workflow` root span only when the execution
+reaches a terminal status. For a short execution this gives one clean trace. For
+a long-running execution, the root span stays open until the execution finishes,
+so you cannot watch the trace in progress, and a span open for hours can exceed
+the ingestion limits of some observability platforms.
+
+`InvocationOtelPlugin` exports each invocation span as that invocation ends. A
+Lambda invocation lasts at most 15 minutes, so spans stay within platform limits
+and appear as the execution runs. This renders reliably across most platforms
+and shows how operations are processed across invocations. Prefer it for
+long-running executions, or when you want to view an execution in progress.
+
+| Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
+| ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Trace root             | Synthetic `Workflow` span                                         | Invocation span (`Workflow` root with the community collector)                   |
+| Root span export       | Only when the execution completes                                 | Each invocation span exports when that invocation ends                           |
+| In-progress visibility | None until the execution finishes                                 | Each invocation appears as it completes                                          |
+| Best for               | Short executions                                                  | Long-running executions, or watching one in progress                             |
+| Platform compatibility | A long-open root span can exceed some platforms' ingestion limits | Invocation spans stay within the 15-minute Lambda limit, so they render reliably |
+
 ## Span structure and attributes
 
 Both plugins open three levels of spans. An invocation span covers one Lambda

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -33,8 +33,8 @@ disconnected trace.
     npm install @aws/durable-execution-sdk-js-otel
     ```
 
-    When the plugin creates its own tracer provider (the default), install the
-    OpenTelemetry packages it configures:
+    When a plugin creates its own tracer provider, install the OpenTelemetry
+    packages it configures:
 
     ```bash
     npm install @opentelemetry/sdk-trace-node \
@@ -44,8 +44,8 @@ disconnected trace.
                 @opentelemetry/resources
     ```
 
-    When you use the ADOT layer's global tracer provider, the layer supplies
-    these packages and you only need `@opentelemetry/api`.
+    When a plugin uses the ADOT layer's global tracer provider, the layer
+    supplies these packages and you only need `@opentelemetry/api`.
 
 === "Python"
 
@@ -81,10 +81,105 @@ disconnected trace.
     </dependency>
     ```
 
-## Register the plugin
+## The two plugins
 
-Add the plugin to your handler configuration. The SDK calls it as the execution
-runs, and you write no tracing code in your handler.
+The package ships two plugins. Both correlate a whole durable execution into a
+single trace with deterministic IDs. They differ in where they root the trace
+and when they export the root span. You register exactly one of them.
+
+### ExecutionOtelPlugin
+
+`ExecutionOtelPlugin` opens a synthetic `Workflow` span as the trace root. Every
+invocation span and operation span nests under it. The plugin exports the
+`Workflow` span only when the execution reaches a terminal status, so an
+execution that is still running does not leave a dangling root span. Choose this
+plugin when you want one unified trace per execution, with the workflow as the
+logical root.
+
+=== "TypeScript"
+
+    ```typescript
+    import { withDurableExecution } from "@aws/durable-execution-sdk-js";
+    import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+    export const handler = withDurableExecution(
+      async (event, context) => {
+        const data = await context.step("fetch-data", async () => fetch(event.id));
+        await context.wait("cooldown", { seconds: 5 });
+        return await context.step("process", async () => transform(data));
+      },
+      { plugins: [new ExecutionOtelPlugin()] },
+    );
+    ```
+
+=== "Python"
+
+    ```python
+    from aws_durable_execution_sdk_python import DurableContext, durable_execution
+    from aws_durable_execution_sdk_python_otel import ExecutionOtelPlugin
+
+
+    @durable_execution(plugins=[ExecutionOtelPlugin()])
+    def handler(event: dict, context: DurableContext) -> dict:
+        data = context.step(lambda ctx: fetch(event["id"]), name="fetch-data")
+        context.wait(duration=Duration.from_seconds(5))
+        return context.step(lambda ctx: transform(data), name="process")
+    ```
+
+=== "Java"
+
+    ```java
+    import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+    import io.opentelemetry.sdk.trace.SdkTracerProvider;
+    import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+    import software.amazon.lambda.durable.DurableConfig;
+    import software.amazon.lambda.durable.DurableContext;
+    import software.amazon.lambda.durable.DurableHandler;
+    import software.amazon.lambda.durable.otel.ExecutionOtelPlugin;
+
+    public class ExampleHandler extends DurableHandler<Event, String> {
+        @Override
+        protected DurableConfig createConfiguration() {
+            var plugin = new ExecutionOtelPlugin(
+                    SdkTracerProvider.builder()
+                            .addSpanProcessor(
+                                    SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
+            return DurableConfig.builder().withPlugins(plugin).build();
+        }
+
+        @Override
+        protected String handleRequest(Event event, DurableContext context) {
+            var data = context.step("fetch-data", String.class, ctx -> fetch(event.id()));
+            context.wait("cooldown", Duration.ofSeconds(5));
+            return context.step("process", String.class, ctx -> transform(data));
+        }
+    }
+    ```
+
+The trace you see groups every invocation of the execution under one `Workflow`
+root:
+
+```text
+Workflow                          (root, exported on terminal status)
+├── Invocation                    (one span per Lambda invocation)
+├── Operation: fetch-data  (STEP)
+│   └── Attempt: fetch-data attempt 1
+├── Operation: cooldown    (WAIT)
+└── Operation: process     (STEP)
+    └── Attempt: process attempt 1
+```
+
+Operation spans link to the invocation span that produced them, so you can tell
+which invocation ran each operation even though the operations root under the
+`Workflow` span.
+
+### InvocationOtelPlugin
+
+`InvocationOtelPlugin` is lighter. It roots each trace at the invocation span and
+attaches operation spans directly to it. With the community collector layer it
+also opens a `Workflow` root span, exported only on terminal status, so you still
+get one unified trace. Choose this plugin when you want per-invocation traces, or
+when you delegate span creation to the ADOT layer.
 
 === "TypeScript"
 
@@ -100,10 +195,6 @@ runs, and you write no tracing code in your handler.
     );
     ```
 
-    The package exports two plugins, `InvocationOtelPlugin` and
-    `ExecutionOtelPlugin`. They register the same way. See
-    [Trace structure](#trace-structure) for how they differ.
-
 === "Python"
 
     ```python
@@ -116,13 +207,7 @@ runs, and you write no tracing code in your handler.
         return context.step(lambda ctx: "done", name="process")
     ```
 
-    The package exports both `InvocationOtelPlugin` and `ExecutionOtelPlugin`.
-    See [Trace structure](#trace-structure) for how they differ.
-
 === "Java"
-
-    The plugin constructor takes the tracer provider builder. Add a span
-    exporter to it, and the plugin sets the deterministic ID generator.
 
     ```java
     import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
@@ -145,32 +230,63 @@ runs, and you write no tracing code in your handler.
 
         @Override
         protected String handleRequest(Object event, DurableContext context) {
-            return context.step("process", String.class, stepCtx -> "done");
+            return context.step("process", String.class, ctx -> "done");
         }
     }
     ```
 
-## Deploy with a Lambda layer
+The trace you see roots at the invocation span:
 
-The plugin produces spans, and a collector transports them from your function to
-your backend. Attach a Lambda layer that runs the collector, enable X-Ray active
-tracing so the runtime populates the `_X_AMZN_TRACE_ID` header the plugin reads,
-and grant the function's role X-Ray write permissions with the
+```text
+Workflow                          (community collector only; terminal status)
+└── Invocation                    (trace root; one span per Lambda invocation)
+    ├── Operation: fetch-data  (STEP)
+    │   └── Attempt: fetch-data attempt 1
+    ├── Operation: cooldown    (WAIT)
+    └── Operation: process     (STEP)
+```
+
+Operations that resume in a later invocation link back to the original
+operation's deterministic span ID, so a retry or a resumed wait relates to its
+first appearance.
+
+## Span structure and attributes
+
+Both plugins open three levels of spans. An invocation span covers one Lambda
+invocation. Operation spans nest one per durable operation, such as a step, wait,
+or child invoke. Attempt spans nest one per try under a step or
+wait-for-condition operation, so retries appear as sibling spans.
+
+| Span       | Attributes                                                                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Invocation | `durable.execution.arn`, `durable.invocation.status`, `durable.invocation.first`                                                                             |
+| Operation  | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status` |
+| Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
+
+`durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
+or `CALLBACK`. The plugin also attaches standard FaaS resource attributes, such
+as the function name and region, from the Lambda environment.
+
+=== "Java"
+
+    Attempt spans are not opened for `CONTEXT` operations, so a child context
+    contributes an operation span but no attempt span.
+
+## Deploy with the ADOT layer
+
+The AWS Distro for OpenTelemetry (ADOT) Lambda layer bundles OpenTelemetry
+auto-instrumentation and a collector extension. The collector listens on
+`localhost:4318` and forwards spans to X-Ray and CloudWatch. Add the layer,
+enable X-Ray active tracing so the runtime populates the `_X_AMZN_TRACE_ID`
+header the plugin reads, and grant the function's role the
 `AWSXRayDaemonWriteAccess` managed policy.
-
-Enabling active tracing matters for trace continuity. Without it,
-`_X_AMZN_TRACE_ID` is unset and the plugin falls back to the execution ARN for
-the trace ID. The traces still form, but resumed invocations can fragment across
-separate trace IDs.
 
 === "TypeScript"
 
-    Use either the AWS Distro for OpenTelemetry (ADOT) layer or the smaller
-    OpenTelemetry community collector layer.
-
-    With the ADOT layer, set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`
-    and construct the plugin with `useDefaultTracerProvider: true` so it uses the
-    layer's global provider:
+    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument` to activate the
+    layer's instrumentation, and construct the plugin with
+    `useDefaultTracerProvider: true` so it uses the layer's global tracer
+    provider.
 
     ```yaml
     MyFunction:
@@ -189,15 +305,16 @@ separate trace IDs.
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
     ```
 
-    With the community collector layer, do not set `AWS_LAMBDA_EXEC_WRAPPER`. The
-    plugin creates its own provider and exports to the collector on
-    `localhost:4318`. Include a `collector.yaml` in your bundle and set
-    `OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path.
+    ```typescript
+    new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+    // or
+    new InvocationOtelPlugin({ useDefaultTracerProvider: true });
+    ```
 
 === "Python"
 
-    Add the ADOT layer and set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`.
-    Find the current layer ARN for your region and architecture in the
+    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`. Find the current
+    layer ARN for your region and architecture in the
     [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python).
 
     ```yaml
@@ -217,12 +334,17 @@ separate trace IDs.
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
     ```
 
+    `InvocationOtelPlugin()` uses the layer's global provider by default.
+    `ExecutionOtelPlugin(OtelPluginConfig(use_default_tracer_provider=True))`
+    does the same.
+
 === "Java"
 
-    Add the ADOT layer, then enable active tracing and X-Ray permissions. Do not
-    set `AWS_LAMBDA_EXEC_WRAPPER`. The wrapper attaches the auto-instrumentation
-    agent, which creates a second tracer provider and splits the trace into
-    disconnected service nodes on the X-Ray map.
+    Add the layer for its collector, but do not set `AWS_LAMBDA_EXEC_WRAPPER`.
+    The Java plugin always builds its own tracer provider from the builder you
+    pass, and the wrapper would attach a second, competing provider that splits
+    the trace into disconnected service nodes on the X-Ray map. Point the
+    plugin's exporter at the layer's collector on `localhost:4318`.
 
     ```yaml
     MyFunction:
@@ -238,73 +360,102 @@ separate trace IDs.
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
     ```
 
-## Trace structure
+**With ExecutionOtelPlugin,** the plugin still opens the `Workflow` root span and
+exports it on terminal status. When it uses the ADOT layer's global provider, it
+does not open its own invocation span. It links operations to the layer's
+ambient invocation span instead.
 
-The plugin opens three levels of spans. An invocation span covers one Lambda
-invocation of the execution. Operation spans nest under it, one per durable
-operation such as a step, wait, or child invoke. Attempt spans nest under a step
-or wait-for-condition operation, one per try, so retries appear as sibling
-spans.
+**With InvocationOtelPlugin,** the plugin delegates span creation to the ADOT
+layer's provider and does not open its own `Workflow` or invocation span.
+Operations attach to the layer's ambient invocation span, so you get
+per-invocation traces correlated by deterministic span IDs rather than one
+`Workflow`-rooted trace.
 
-Because trace and span IDs derive from the execution ARN and each operation's ID,
-an operation that starts in one invocation and completes in a later one links
-back to its original span. All invocations of one execution share a single trace
-ID.
+## Deploy with the community collector layer
 
-Both `InvocationOtelPlugin` and `ExecutionOtelPlugin` correlate a whole execution
-into one trace. They differ in the trace root.
+The OpenTelemetry community collector layer runs a collector extension only,
+without auto-instrumentation, so it is smaller than the ADOT layer. The plugin
+creates its own tracer provider and exports spans to the collector on
+`localhost:4318`. Do not set `AWS_LAMBDA_EXEC_WRAPPER` with this layer.
+
+Include a `collector.yaml` in your function bundle and set
+`OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+exporters:
+  awsxray:
+    region: "${AWS_REGION}"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [awsxray]
+```
+
+Routing spans through a collector also lets you export to a third-party platform
+such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
+without first sending them to X-Ray.
 
 === "TypeScript"
 
-    `ExecutionOtelPlugin` opens a synthetic `Workflow` span as the trace root and
-    exports it only when the execution reaches a terminal status, so incomplete
-    executions do not leave dangling roots. `InvocationOtelPlugin` roots the trace
-    at each invocation span, and with the community collector it also opens the
-    `Workflow` root. Configure both with the shared `OtelPluginConfig`.
+    Construct either plugin with no provider option. It auto-creates a provider
+    that exports to `localhost:4318`.
+
+    ```yaml
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:184161586896:layer:opentelemetry-nodejs-0_22_0:1
+    Environment:
+      Variables:
+        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```
 
     ```typescript
-    import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
-
-    const plugin = new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+    new ExecutionOtelPlugin();   // auto-creates a provider
+    new InvocationOtelPlugin();  // auto-creates a provider
     ```
 
 === "Python"
 
-    `ExecutionOtelPlugin` opens a `Workflow` root span and takes an
-    `OtelPluginConfig`. `InvocationOtelPlugin` roots the trace at the invocation
-    span and takes keyword arguments.
+    `ExecutionOtelPlugin()` auto-creates a provider that exports to the collector.
+    `InvocationOtelPlugin` does not auto-create a provider. It uses the globally
+    configured provider, so with the community collector layer, pass an explicit
+    provider through `trace_provider`, or use `ExecutionOtelPlugin`.
 
-    ```python
-    from aws_durable_execution_sdk_python_otel import (
-        ExecutionOtelPlugin,
-        OtelPluginConfig,
-    )
-
-    plugin = ExecutionOtelPlugin(OtelPluginConfig(use_default_tracer_provider=True))
+    ```yaml
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>
+    Environment:
+      Variables:
+        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
     ```
 
 === "Java"
 
-    `InvocationOtelPlugin` opens a `Workflow` root span whose name you can set
-    through the constructor. The service name on the exported spans' resource is
-    `invocation`.
+    Both plugins already build their own provider from the builder you pass, so
+    add an OTLP exporter pointed at `localhost:4318`. This is the same wiring
+    shown in [The two plugins](#the-two-plugins).
 
-The spans carry these attributes.
+    ```yaml
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>
+    Environment:
+      Variables:
+        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```
 
-| Span       | Attributes                                                                                                                                                   |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Invocation | `durable.execution.arn`, `durable.invocation.status`, `durable.invocation.first`                                                                             |
-| Operation  | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status` |
-| Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
+**With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
+The plugin exports the `Workflow` span only on terminal status, so intermediate
+invocations do not emit incomplete workflow spans.
 
-`durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
-or `CALLBACK`. The plugin also attaches standard FaaS resource attributes, such
-as the function name and region, from the Lambda environment.
-
-=== "Java"
-
-    Attempt spans are not opened for `CONTEXT` operations, so a child context
-    contributes an operation span but no attempt span.
+**With InvocationOtelPlugin,** the plugin opens a synthetic `Workflow` root span
+with a deterministic ID and an invocation span as its child. It exports the
+`Workflow` span only on terminal status, so you still get one clean trace across
+invocations.
 
 ## Configuration
 
@@ -336,6 +487,11 @@ as the function name and region, from the Lambda environment.
 
 === "Python"
 
+    `ExecutionOtelPlugin` takes an `OtelPluginConfig` dataclass with
+    `tracer_provider`, `use_default_tracer_provider`, `context_extractor`,
+    `exporter_config`, `propagators`, `enable_http_instrumentation`,
+    `instrument_name`, `workflow_span_name`, and `enrich_logger`.
+
     `InvocationOtelPlugin` takes keyword arguments.
 
     - **trace_provider** A tracer provider to use. Defaults to the globally
@@ -347,17 +503,13 @@ as the function name and region, from the Lambda environment.
     - **enrich_logger** Installs a root-logger filter that stamps trace context
         onto log records. Defaults to `True`.
 
-    `ExecutionOtelPlugin` takes an `OtelPluginConfig` dataclass with the same
-    provider, extractor, exporter, and `workflow_span_name` options as the
-    TypeScript config.
-
     Control sampling through the ADOT layer with `OTEL_TRACES_SAMPLER` and
     `OTEL_TRACES_SAMPLER_ARG`.
 
 === "Java"
 
-    The constructor takes the tracer provider builder and three optional
-    arguments.
+    Each plugin's constructor takes the tracer provider builder and three
+    optional arguments.
 
     ```java
     new InvocationOtelPlugin(tracerProviderBuilder);

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -217,7 +217,7 @@ header the plugin reads, and grant the function's role the
     MyFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Runtime: nodejs22.x
+        Runtime: nodejs24.x
         Handler: index.handler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-js-layer>:<version>
@@ -246,7 +246,7 @@ header the plugin reads, and grant the function's role the
     MyFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Runtime: python3.12
+        Runtime: python3.14
         Handler: index.handler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-python-layer>:<version>
@@ -278,7 +278,7 @@ header the plugin reads, and grant the function's role the
     MyFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Runtime: java17
+        Runtime: java21
         Handler: com.example.ExampleHandler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-java-layer>:<version>

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -134,7 +134,7 @@ which invocation ran each operation even though the operations root under the
 
 `InvocationOtelPlugin` is lighter. It roots each trace at the invocation span and
 attaches operation spans directly to it. With the community collector layer it
-also opens a `Workflow` root span, exported only on terminal status. 
+also opens a `Workflow` root span, exported only on terminal status.
 Choose this plugin when you want per-invocation traces, or
 when you delegate span creation to the ADOT layer.
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -434,7 +434,7 @@ each Lambda invocation.
     - **exporterConfig** OTLP `endpoint` and `headers`, used only when the plugin
         creates its own provider.
     - **propagators** Replaces the default `[AWSXRay, W3CTraceContext]`
-        propagators. W3CTraceContext currently does no work in Lambda.
+        propagators. W3CTraceContext currently does not work in Lambda.
     - **enableHttpInstrumentation** Registers HTTP instrumentation. Defaults to
         `true`.
     - **instrumentationName** Instrumentation scope name. Defaults to

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -373,7 +373,7 @@ without first sending them to Cloudwatch or X-Ray.
     ```
 
     ```java
-    var exporter = OtlpGrpcSpanExporter.getDefault();
+    var exporter = OtlpHttpSpanExporter.getDefault();
     var plugin = new ExecutionOtelPlugin(
             SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)));
     ```

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -128,16 +128,22 @@ traces that still correlate to one workflow.
     ```
 
 The `Workflow` span is a parentless root that operation and attempt spans link
-to. The invocation span roots the per-invocation view separately:
+to. Each Lambda invocation roots its own view. The example above suspends at the
+`cooldown` wait, so it runs across two invocations, and the wait produces a span
+in each:
 
 ```text
-Workflow                          (parentless root; deterministic ID; ended at terminal invocation)
+Workflow                              (parentless root; deterministic ID; ended at the terminal invocation)
 
-Invocation                        (per-invocation root; not nested under Workflow)
+Invocation #1                         (per-invocation root; not nested under Workflow)
 ├── Operation: fetch-data  (STEP)      -> link to Workflow
 │   └── Attempt: fetch-data attempt 1  -> link to Workflow
-├── Operation: cooldown    (WAIT)      -> link to Workflow
+└── Operation: cooldown    (WAIT)      -> link to Workflow      (wait starts; execution suspends)
+
+Invocation #2                         (per-invocation root; resumes after the wait)
+├── Operation: cooldown    (WAIT)      -> link to the first cooldown span, and to Workflow
 └── Operation: process     (STEP)      -> link to Workflow
+    └── Attempt: process attempt 1     -> link to Workflow
 ```
 
 An operation that completes in a later invocation, such as an invoke, wait, or
@@ -209,7 +215,7 @@ header the plugin reads, and grant the function's role the
     `useDefaultTracerProvider: true` so it uses the layer's global tracer
     provider. Find the current ADOT JavaScript layer ARN for your region and
     architecture in the
-    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js).
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
 
     ```yaml
     MyFunction:
@@ -238,7 +244,7 @@ header the plugin reads, and grant the function's role the
 
     Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`. Find the current
     layer ARN for your region and architecture in the
-    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python).
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
 
     ```yaml
     MyFunction:
@@ -270,7 +276,7 @@ header the plugin reads, and grant the function's role the
     construct either plugin with the no-arg constructor, which reads the agent's
     global provider. Find the current ADOT Java layer ARN for your region and
     architecture in the
-    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java).
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
 
     ```yaml
     MyFunction:
@@ -300,8 +306,8 @@ The plugin exports the `Workflow` span only on terminal status.
 
 **With InvocationOtelPlugin,** you get per-invocation traces that correlate to
 one `Workflow` span through links. The plugin always creates its own invocation
-span; under the ADOT layer it parents that span to the layer's ambient Lambda
-span.
+span; with `useDefaultTracerProvider: true` it parents that span to the layer's
+ambient Lambda span.
 
 ## Deploy with the community collector layer
 
@@ -335,8 +341,8 @@ without first sending them to CloudWatch or X-Ray.
 
 === "TypeScript"
 
-    Construct either plugin with no provider option. It auto-creates a provider
-    that exports to `localhost:4318`.
+    Construct either plugin with `useDefaultTracerProvider: false` (the default),
+    so it auto-creates a provider that exports to `localhost:4318`.
 
     ```yaml
     Layers:
@@ -347,8 +353,8 @@ without first sending them to CloudWatch or X-Ray.
     ```
 
     ```typescript
-    new ExecutionOtelPlugin();   // auto-creates a provider
-    new InvocationOtelPlugin();  // auto-creates a provider
+    new ExecutionOtelPlugin({ useDefaultTracerProvider: false });
+    new InvocationOtelPlugin({ useDefaultTracerProvider: false });
     ```
 
 === "Python"

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -134,8 +134,8 @@ which invocation ran each operation even though the operations root under the
 
 `InvocationOtelPlugin` is lighter. It roots each trace at the invocation span and
 attaches operation spans directly to it. With the community collector layer it
-also opens a `Workflow` root span, exported only on terminal status, so you still
-get one unified trace. Choose this plugin when you want per-invocation traces, or
+also opens a `Workflow` root span, exported only on terminal status. 
+Choose this plugin when you want per-invocation traces, or
 when you delegate span creation to the ADOT layer.
 
 === "TypeScript"
@@ -185,7 +185,11 @@ the ingestion limits of some observability platforms.
 Lambda invocation lasts at most 15 minutes, so spans stay within platform limits
 and appear as the execution runs. This renders reliably across most platforms
 and shows how operations are processed across invocations. Prefer it for
-long-running executions, or when you want to view an execution in progress.
+long-running executions, or when you want to view an execution in progress. Operations
+which complete between Lambda invocations such as invoke, wait or callback may appear to be split
+into multiple spans, spanning multiple invocations. The plugin provides a Link from the subsequent
+spans linking to the first such operation span. Note that Cloudwatch doesn't implement Links and doesn't
+currently visualize them.
 
 | Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
 | ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -325,7 +329,7 @@ their own spans through the layer's provider.
 ## Deploy with the community collector layer
 
 The OpenTelemetry community collector layer runs a collector extension only,
-without auto-instrumentation, so it is smaller than the ADOT layer. The plugin
+without auto-instrumentation. The plugin
 creates its own tracer provider and exports spans to the collector on
 `localhost:4318`. Do not set `AWS_LAMBDA_EXEC_WRAPPER` with this layer.
 
@@ -350,7 +354,7 @@ service:
 
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
-without first sending them to X-Ray.
+without first sending them to Cloudwatch or X-Ray.
 
 === "TypeScript"
 
@@ -411,8 +415,8 @@ invocations do not emit incomplete workflow spans.
 
 **With InvocationOtelPlugin,** the plugin opens a synthetic `Workflow` root span
 with a deterministic ID and an invocation span as its child. It exports the
-`Workflow` span only on terminal status, so you still get one clean trace across
-invocations.
+`Workflow` span only on terminal status. Invocation spans are exporteed at the end of
+each Lambda invocation.
 
 ## Configuration
 
@@ -426,11 +430,11 @@ invocations.
         the ADOT layer's. Defaults to `false`.
     - **contextExtractor** Extracts upstream trace context. Defaults to
         `xRayContextExtractor`. Use `w3cClientContextExtractor` for W3C
-        `traceparent` propagation.
+        `traceparent` propagation. `w3cClientContextExtractor` currently does no work in Lambda.
     - **exporterConfig** OTLP `endpoint` and `headers`, used only when the plugin
         creates its own provider.
     - **propagators** Replaces the default `[AWSXRay, W3CTraceContext]`
-        propagators.
+        propagators. W3CTraceContext currently does no work in Lambda.
     - **enableHttpInstrumentation** Registers HTTP instrumentation. Defaults to
         `true`.
     - **instrumentationName** Instrumentation scope name. Defaults to
@@ -454,7 +458,8 @@ invocations.
     - **trace_provider** A tracer provider to use. Defaults to the globally
         configured provider.
     - **context_extractor** Defaults to `xray_context_extractor`. Use
-        `w3c_client_context_extractor` for W3C `traceparent` propagation.
+        `w3c_client_context_extractor` for W3C `traceparent` propagation. W3C
+        `traceparent` propagation is currently not working in Lambda.
     - **instrument_name** Instrumentation scope name. Defaults to
         `aws-durable-execution-sdk-python`.
     - **enrich_logger** Installs a root-logger filter that stamps trace context

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -99,61 +99,19 @@ logical root.
 === "TypeScript"
 
     ```typescript
-    import { withDurableExecution } from "@aws/durable-execution-sdk-js";
-    import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
-
-    export const handler = withDurableExecution(
-      async (event, context) => {
-        const data = await context.step("fetch-data", async () => fetch(event.id));
-        await context.wait("cooldown", { seconds: 5 });
-        return await context.step("process", async () => transform(data));
-      },
-      { plugins: [new ExecutionOtelPlugin()] },
-    );
+    --8<-- "examples/typescript/sdk-reference/observability/opentelemetry/execution-plugin.ts"
     ```
 
 === "Python"
 
     ```python
-    from aws_durable_execution_sdk_python import DurableContext, durable_execution
-    from aws_durable_execution_sdk_python_otel import ExecutionOtelPlugin
-
-
-    @durable_execution(plugins=[ExecutionOtelPlugin()])
-    def handler(event: dict, context: DurableContext) -> dict:
-        data = context.step(lambda ctx: fetch(event["id"]), name="fetch-data")
-        context.wait(duration=Duration.from_seconds(5))
-        return context.step(lambda ctx: transform(data), name="process")
+    --8<-- "examples/python/sdk-reference/observability/opentelemetry/execution-plugin.py"
     ```
 
 === "Java"
 
     ```java
-    import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-    import io.opentelemetry.sdk.trace.SdkTracerProvider;
-    import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-    import software.amazon.lambda.durable.DurableConfig;
-    import software.amazon.lambda.durable.DurableContext;
-    import software.amazon.lambda.durable.DurableHandler;
-    import software.amazon.lambda.durable.otel.ExecutionOtelPlugin;
-
-    public class ExampleHandler extends DurableHandler<Event, String> {
-        @Override
-        protected DurableConfig createConfiguration() {
-            var plugin = new ExecutionOtelPlugin(
-                    SdkTracerProvider.builder()
-                            .addSpanProcessor(
-                                    SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
-            return DurableConfig.builder().withPlugins(plugin).build();
-        }
-
-        @Override
-        protected String handleRequest(Event event, DurableContext context) {
-            var data = context.step("fetch-data", String.class, ctx -> fetch(event.id()));
-            context.wait("cooldown", Duration.ofSeconds(5));
-            return context.step("process", String.class, ctx -> transform(data));
-        }
-    }
+    --8<-- "examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java"
     ```
 
 The trace you see groups every invocation of the execution under one `Workflow`
@@ -184,55 +142,19 @@ when you delegate span creation to the ADOT layer.
 === "TypeScript"
 
     ```typescript
-    import { withDurableExecution } from "@aws/durable-execution-sdk-js";
-    import { InvocationOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
-
-    export const handler = withDurableExecution(
-      async (event, context) => {
-        return await context.step("process", async () => "done");
-      },
-      { plugins: [new InvocationOtelPlugin()] },
-    );
+    --8<-- "examples/typescript/sdk-reference/observability/opentelemetry/invocation-plugin.ts"
     ```
 
 === "Python"
 
     ```python
-    from aws_durable_execution_sdk_python import DurableContext, durable_execution
-    from aws_durable_execution_sdk_python_otel import InvocationOtelPlugin
-
-
-    @durable_execution(plugins=[InvocationOtelPlugin()])
-    def handler(event: dict, context: DurableContext) -> str:
-        return context.step(lambda ctx: "done", name="process")
+    --8<-- "examples/python/sdk-reference/observability/opentelemetry/invocation-plugin.py"
     ```
 
 === "Java"
 
     ```java
-    import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-    import io.opentelemetry.sdk.trace.SdkTracerProvider;
-    import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-    import software.amazon.lambda.durable.DurableConfig;
-    import software.amazon.lambda.durable.DurableContext;
-    import software.amazon.lambda.durable.DurableHandler;
-    import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
-
-    public class ExampleHandler extends DurableHandler<Object, String> {
-        @Override
-        protected DurableConfig createConfiguration() {
-            var plugin = new InvocationOtelPlugin(
-                    SdkTracerProvider.builder()
-                            .addSpanProcessor(
-                                    SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
-            return DurableConfig.builder().withPlugins(plugin).build();
-        }
-
-        @Override
-        protected String handleRequest(Object event, DurableContext context) {
-            return context.step("process", String.class, ctx -> "done");
-        }
-    }
+    --8<-- "examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java"
     ```
 
 The trace you see roots at the invocation span:
@@ -264,8 +186,7 @@ wait-for-condition operation, so retries appear as sibling spans.
 | Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
 
 `durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
-or `CALLBACK`. The plugin also attaches standard FaaS resource attributes, such
-as the function name and region, from the Lambda environment.
+or `CALLBACK`.
 
 === "Java"
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -51,8 +51,9 @@ disconnected trace.
 ## The two plugins
 
 The package ships two plugins. Both correlate a whole durable execution into a
-single trace with deterministic IDs. They differ in where they root the trace
-and when they export the root span. You register exactly one of them.
+single trace with deterministic IDs, and both emit a `Workflow` root span for the
+execution. They differ in where they root the invocation view and when they
+export the root span. You register exactly one of them.
 
 ### ExecutionOtelPlugin
 
@@ -100,11 +101,13 @@ which invocation ran each operation even though the operations root under the
 
 ### InvocationOtelPlugin
 
-`InvocationOtelPlugin` is lighter. It roots each trace at the invocation span and
-attaches operation spans directly to it. With the community collector layer it
-also opens a `Workflow` root span, exported only on terminal status.
-Choose this plugin when you want per-invocation traces, or
-when you delegate span creation to the ADOT layer.
+`InvocationOtelPlugin` keeps the trace invocation-rooted. It opens a parentless
+`Workflow` root span in both provider modes, keyed to a deterministic ID from the
+execution ARN and ended only at the terminal invocation. The invocation span is
+not a child of that `Workflow` span. Each invocation span roots its own operation
+and attempt spans, and those spans carry a link to the `Workflow` span for
+execution-scoped correlation. Choose this plugin when you want per-invocation
+traces that still correlate to one workflow.
 
 === "TypeScript"
 
@@ -124,20 +127,24 @@ when you delegate span creation to the ADOT layer.
     --8<-- "examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java"
     ```
 
-The trace you see roots at the invocation span:
+The `Workflow` span is a parentless root that operation and attempt spans link
+to. The invocation span roots the per-invocation view separately:
 
 ```text
-Workflow                          (community collector only; terminal status)
-└── Invocation                    (trace root; one span per Lambda invocation)
-    ├── Operation: fetch-data  (STEP)
-    │   └── Attempt: fetch-data attempt 1
-    ├── Operation: cooldown    (WAIT)
-    └── Operation: process     (STEP)
+Workflow                          (parentless root; deterministic ID; ended at terminal invocation)
+
+Invocation                        (per-invocation root; not nested under Workflow)
+├── Operation: fetch-data  (STEP)      -> link to Workflow
+│   └── Attempt: fetch-data attempt 1  -> link to Workflow
+├── Operation: cooldown    (WAIT)      -> link to Workflow
+└── Operation: process     (STEP)      -> link to Workflow
 ```
 
-Operations that resume in a later invocation link back to the original
-operation's deterministic span ID, so a retry or a resumed wait relates to its
-first appearance.
+An operation that completes in a later invocation, such as an invoke, wait, or
+callback, can appear as more than one span across invocations. Each later span
+carries a link back to the first span for that operation, so a retry or a resumed
+wait relates to its first appearance. CloudWatch does not yet visualize these
+links.
 
 ### Choosing a plugin
 
@@ -153,43 +160,38 @@ the ingestion limits of some observability platforms.
 Lambda invocation lasts at most 15 minutes, so spans stay within platform limits
 and appear as the execution runs. This renders reliably across most platforms
 and shows how operations are processed across invocations. Prefer it for
-long-running executions, or when you want to view an execution in progress. Operations
-which complete between Lambda invocations such as invoke, wait or callback may appear to be split
-into multiple spans, spanning multiple invocations. The plugin provides a Link from the subsequent
-spans linking to the first such operation span. Note that Cloudwatch doesn't implement Links and doesn't
-currently visualize them.
+long-running executions, or when you want to view an execution in progress.
 
-Note that for both plugins, observability platform quotas/limitations will apply.
+For both plugins, your observability platform's quotas and limits apply.
 
 | Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
 | ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Trace root             | Synthetic `Workflow` span                                         | Invocation span (`Workflow` root with the community collector)                   |
+| Trace root             | Synthetic `Workflow` span                                         | Invocation span; a `Workflow` span is also emitted and linked from operations    |
 | Root span export       | Only when the execution completes                                 | Each invocation span exports when that invocation ends                           |
-| Operation span         | Exported in its entirety, once when complete                      | May be duplicated under multiple invocations spans                               |
+| Operation span         | Exported once, in its entirety, when complete                     | Can appear under multiple invocation spans                                       |
 | In-progress visibility | Fragmented until the execution finishes                           | Each invocation appears as it completes                                          |
 | Better for             | Short executions                                                  | Longer-running executions, or watching one in progress                           |
 | Platform compatibility | A long-open root span can exceed some platforms' ingestion limits | Invocation spans stay within the 15-minute Lambda limit, so they render reliably |
 
 ## Span structure and attributes
 
-Both plugins open three levels of spans. An invocation span covers one Lambda
-invocation. Operation spans nest one per durable operation, such as a step, wait,
-or child invoke. Attempt spans nest one per try under a step or
-wait-for-condition operation, so retries appear as sibling spans.
+Both plugins emit a `Workflow` root span for the whole execution. Beneath it
+(ExecutionOtelPlugin) or linked to it (InvocationOtelPlugin) sit three levels of
+spans. An invocation span covers one Lambda invocation. Operation spans nest one
+per durable operation, such as a step, wait, or child invoke. Attempt spans nest
+one per try under a step or wait-for-condition operation, so retries appear as
+sibling spans.
 
 | Span       | Attributes                                                                                                                                                   |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Workflow   | `durable.execution.arn`, `durable.execution.status`                                                                                                          |
 | Invocation | `durable.execution.arn`, `durable.invocation.status`, `durable.invocation.first`                                                                             |
 | Operation  | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status` |
 | Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
 
 `durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
-or `CALLBACK`.
-
-=== "Java"
-
-    Attempt spans are not opened for `CONTEXT` operations, so a child context
-    contributes an operation span but no attempt span.
+or `CALLBACK`. A `CONTEXT` operation (a child context) gets an operation span but
+no attempt span, since attempt spans apply only to steps and wait-for-conditions.
 
 ## Deploy with the ADOT layer
 
@@ -205,7 +207,9 @@ header the plugin reads, and grant the function's role the
     Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument` to activate the
     layer's instrumentation, and construct the plugin with
     `useDefaultTracerProvider: true` so it uses the layer's global tracer
-    provider.
+    provider. Find the current ADOT JavaScript layer ARN for your region and
+    architecture in the
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js).
 
     ```yaml
     MyFunction:
@@ -214,7 +218,7 @@ header the plugin reads, and grant the function's role the
         Runtime: nodejs22.x
         Handler: index.handler
         Layers:
-          - !Sub arn:aws:lambda:${AWS::Region}:615299751070:layer:AWSOpenTelemetryDistroJs:7
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-js-layer>:<version>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
@@ -264,7 +268,9 @@ header the plugin reads, and grant the function's role the
     `OTEL_JAVAAGENT_EXTENSIONS` (the path to the bundled plugin jar) so its SPI
     installs deterministic ID generation into the agent's provider. Then
     construct either plugin with the no-arg constructor, which reads the agent's
-    global provider.
+    global provider. Find the current ADOT Java layer ARN for your region and
+    architecture in the
+    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java).
 
     ```yaml
     MyFunction:
@@ -273,7 +279,7 @@ header the plugin reads, and grant the function's role the
         Runtime: java17
         Handler: com.example.ExampleHandler
         Layers:
-          - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-java-agent-amd64-ver-1-32-0:6
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-java-layer>:<version>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
@@ -292,10 +298,10 @@ header the plugin reads, and grant the function's role the
 **With ExecutionOtelPlugin,** you get one `Workflow`-rooted trace per execution.
 The plugin exports the `Workflow` span only on terminal status.
 
-**With InvocationOtelPlugin,** you get per-invocation traces correlated across
-invocations by deterministic span IDs. In TypeScript, this plugin can delegate
-span creation to the ADOT layer's ambient invocation span; Python and Java open
-their own spans through the layer's provider.
+**With InvocationOtelPlugin,** you get per-invocation traces that correlate to
+one `Workflow` span through links. The plugin always creates its own invocation
+span; under the ADOT layer it parents that span to the layer's ambient Lambda
+span.
 
 ## Deploy with the community collector layer
 
@@ -325,7 +331,7 @@ service:
 
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
-without first sending them to Cloudwatch or X-Ray.
+without first sending them to CloudWatch or X-Ray.
 
 === "TypeScript"
 
@@ -384,10 +390,11 @@ without first sending them to Cloudwatch or X-Ray.
 The plugin exports the `Workflow` span only on terminal status, so intermediate
 invocations do not emit incomplete workflow spans.
 
-**With InvocationOtelPlugin,** the plugin opens a synthetic `Workflow` root span
-with a deterministic ID and an invocation span as its child. It exports the
-`Workflow` span only on terminal status. Invocation spans are exporteed at the end of
-each Lambda invocation.
+**With InvocationOtelPlugin,** the plugin opens the parentless `Workflow` root
+span with a deterministic ID and exports it only on terminal status. The
+invocation span is not a child of the `Workflow` span; it roots the per-invocation
+view and links to the `Workflow` span. The plugin exports each invocation span at
+the end of its Lambda invocation.
 
 ## Configuration
 
@@ -435,6 +442,8 @@ each Lambda invocation.
         `aws-durable-execution-sdk-python`.
     - **enrich_logger** Installs a root-logger filter that stamps trace context
         onto log records. Defaults to `True`.
+    - **workflow_span_name** Name of the `Workflow` root span. Defaults to
+        `Workflow`.
 
     Control sampling through the ADOT layer with `OTEL_TRACES_SAMPLER` and
     `OTEL_TRACES_SAMPLER_ARG`.

--- a/examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java
+++ b/examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java
@@ -1,0 +1,27 @@
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.util.Map;
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.otel.ExecutionOtelPlugin;
+
+public class ExecutionOtelExample extends DurableHandler<Map<String, String>, String> {
+    @Override
+    protected DurableConfig createConfiguration() {
+        var plugin = new ExecutionOtelPlugin(
+                SdkTracerProvider.builder()
+                        .addSpanProcessor(
+                                SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
+        return DurableConfig.builder().withPlugins(plugin).build();
+    }
+
+    @Override
+    protected String handleRequest(Map<String, String> event, DurableContext context) {
+        String data = context.step("fetch-data", String.class, ctx -> event.get("id"));
+        context.wait("cooldown", Duration.ofSeconds(5));
+        return context.step("process", String.class, ctx -> "processed " + data);
+    }
+}

--- a/examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java
+++ b/examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java
@@ -1,6 +1,3 @@
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.time.Duration;
 import java.util.Map;
 import software.amazon.lambda.durable.DurableConfig;
@@ -11,11 +8,7 @@ import software.amazon.lambda.durable.otel.ExecutionOtelPlugin;
 public class ExecutionOtelExample extends DurableHandler<Map<String, String>, String> {
     @Override
     protected DurableConfig createConfiguration() {
-        var plugin = new ExecutionOtelPlugin(
-                SdkTracerProvider.builder()
-                        .addSpanProcessor(
-                                SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
-        return DurableConfig.builder().withPlugins(plugin).build();
+        return DurableConfig.builder().withPlugins(new ExecutionOtelPlugin()).build();
     }
 
     @Override

--- a/examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java
+++ b/examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java
@@ -1,6 +1,3 @@
-import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import software.amazon.lambda.durable.DurableConfig;
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
@@ -9,11 +6,7 @@ import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
 public class InvocationOtelExample extends DurableHandler<Object, String> {
     @Override
     protected DurableConfig createConfiguration() {
-        var plugin = new InvocationOtelPlugin(
-                SdkTracerProvider.builder()
-                        .addSpanProcessor(
-                                SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
-        return DurableConfig.builder().withPlugins(plugin).build();
+        return DurableConfig.builder().withPlugins(new InvocationOtelPlugin()).build();
     }
 
     @Override

--- a/examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java
+++ b/examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java
@@ -1,0 +1,23 @@
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import software.amazon.lambda.durable.DurableConfig;
+import software.amazon.lambda.durable.DurableContext;
+import software.amazon.lambda.durable.DurableHandler;
+import software.amazon.lambda.durable.otel.InvocationOtelPlugin;
+
+public class InvocationOtelExample extends DurableHandler<Object, String> {
+    @Override
+    protected DurableConfig createConfiguration() {
+        var plugin = new InvocationOtelPlugin(
+                SdkTracerProvider.builder()
+                        .addSpanProcessor(
+                                SimpleSpanProcessor.create(OtlpGrpcSpanExporter.getDefault())));
+        return DurableConfig.builder().withPlugins(plugin).build();
+    }
+
+    @Override
+    protected String handleRequest(Object event, DurableContext context) {
+        return context.step("process", String.class, ctx -> "done");
+    }
+}

--- a/examples/python/sdk-reference/observability/opentelemetry/execution-plugin.py
+++ b/examples/python/sdk-reference/observability/opentelemetry/execution-plugin.py
@@ -1,0 +1,10 @@
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+from aws_durable_execution_sdk_python.config import Duration
+from aws_durable_execution_sdk_python_otel import ExecutionOtelPlugin
+
+
+@durable_execution(plugins=[ExecutionOtelPlugin()])
+def handler(event: dict, context: DurableContext) -> str:
+    data = context.step(lambda ctx: event["id"], name="fetch-data")
+    context.wait(Duration.from_seconds(5), name="cooldown")
+    return context.step(lambda ctx: f"processed {data}", name="process")

--- a/examples/python/sdk-reference/observability/opentelemetry/invocation-plugin.py
+++ b/examples/python/sdk-reference/observability/opentelemetry/invocation-plugin.py
@@ -1,0 +1,7 @@
+from aws_durable_execution_sdk_python import DurableContext, durable_execution
+from aws_durable_execution_sdk_python_otel import InvocationOtelPlugin
+
+
+@durable_execution(plugins=[InvocationOtelPlugin()])
+def handler(event: dict, context: DurableContext) -> str:
+    return context.step(lambda ctx: "done", name="process")

--- a/examples/typescript/sdk-reference/observability/opentelemetry/execution-plugin.ts
+++ b/examples/typescript/sdk-reference/observability/opentelemetry/execution-plugin.ts
@@ -1,0 +1,11 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+export const handler = withDurableExecution(
+  async (event: { id: string }, context: DurableContext) => {
+    const data = await context.step("fetch-data", async () => event.id);
+    await context.wait("cooldown", { seconds: 5 });
+    return await context.step("process", async () => `processed ${data}`);
+  },
+  { plugins: [new ExecutionOtelPlugin()] },
+);

--- a/examples/typescript/sdk-reference/observability/opentelemetry/invocation-plugin.ts
+++ b/examples/typescript/sdk-reference/observability/opentelemetry/invocation-plugin.ts
@@ -1,0 +1,9 @@
+import { DurableContext, withDurableExecution } from "@aws/durable-execution-sdk-js";
+import { InvocationOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+
+export const handler = withDurableExecution(
+  async (event, context: DurableContext) => {
+    return await context.step("process", async () => "done");
+  },
+  { plugins: [new InvocationOtelPlugin()] },
+);

--- a/zensical.toml
+++ b/zensical.toml
@@ -82,6 +82,7 @@ nav = [
     { "Observability" = [
       { "Logging" = "sdk-reference/observability/logging.md" },
       { "Plugins" = "sdk-reference/observability/plugins.md" },
+      { "OpenTelemetry" = "sdk-reference/observability/opentelemetry.md" },
     ]},
     { "Configuration" = [
       { "Configuration" = "sdk-reference/configuration/index.md" },


### PR DESCRIPTION
## issue

#236

## What

Adds a new **OpenTelemetry** page under SDK Reference → Observability
documenting the `aws-durable-execution-sdk-<language>-otel` plugin packages.

Covers TypeScript, Python, and Java (the languages with a released plugin):
install, register the plugin, deploy with a Lambda layer (ADOT and the
community collector layer), trace structure and span attributes,
configuration, and log correlation. C# is noted as arriving when the .NET
Durable Execution SDK becomes generally available.

New page is wired into the Observability nav after Plugins.

## Where

- `docs/sdk-reference/observability/opentelemetry.md` (new)
- `zensical.toml` (nav entry)

It lives beside the existing `plugins.md` (the generic plugin interface it
builds on) and `logging.md` (log correlation), and links to both rather than
duplicating them.

## Checks

- mdformat (repo `[tool.mdformat]` config) and codespell: clean
- No emdash / hyphen-as-dash
- `zensical build --clean`: **No issues found**
