### PR TITLE
docs(otel): clarify awsxray exporter sends spans to CloudWatch

### DIFF
--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -323,6 +323,9 @@ service:
       exporters: [awsxray]
 ```
 
+The collector's AWS trace exporter is named `awsxray`, but the spans land in
+CloudWatch.
+
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
 without first sending them to CloudWatch. Check https://github.com/open-telemetry/opentelemetry-lambda/releases

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -12,6 +12,9 @@ trace header when one is present, so the spans from every invocation join a
 single trace. Without deterministic IDs, each invocation would produce its own
 disconnected trace.
 
+Some names on this page keep the X-Ray label (for example the X-Ray trace
+header and the `awsxray` collector exporter), but your spans land in CloudWatch.
+
 !!! note "Experimental feature"
 
     The OpenTelemetry plugin is experimental and may change in a future
@@ -322,9 +325,6 @@ service:
       receivers: [otlp]
       exporters: [awsxray]
 ```
-
-The collector's AWS trace exporter is named `awsxray`, but the spans land in
-CloudWatch.
 
 Routing spans through a collector also lets you export to a third-party platform
 such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,


### PR DESCRIPTION
## What

Adds a one-line clarifier to the OpenTelemetry page's community-collector section: the collector's AWS trace exporter is named `awsxray`, but spans land in CloudWatch.

## Why

Addresses review comment on PR #237: https://github.com/aws/aws-durable-execution-docs/pull/237#discussion_r3717062872

The page now frames the backend as CloudWatch, but the `collector.yaml` uses the `awsxray:` exporter (the correct exporter name for AWS trace ingestion). Without a note, a reader may do a double-take. This adds the clarifier right after the `collector.yaml` block.

## File

- `docs/sdk-reference/observability/opentelemetry.md`

## Checks

- mdformat + codespell: clean
- `zensical build --clean`: No issues found
