### PR TITLE
feat(testing): replace DURABLE_EXECUTION_TIME_SCALE with skip_time for Python

### DIFF
--- a/docs/testing/api-reference.md
+++ b/docs/testing/api-reference.md
@@ -471,10 +471,15 @@ CI.
 
 === "Python"
 
-    Set the `DURABLE_EXECUTION_TIME_SCALE` environment variable to a float that multiplies
-    `context.wait()` durations. Step retry delays use the configured
-    `next_attempt_delay_seconds` at real wall-clock time and the scale does not apply to
-    them.
+    Pass `skip_time=True` to `DurableFunctionTestRunner`. The runner uses a virtual clock
+    that skips modeled delays instantly. Both `context.wait()` durations and step retry
+    delays complete in zero wall-clock time. `skip_time` defaults to `True`.
+
+    ```python
+    runner = DurableFunctionTestRunner(handler=handler, skip_time=True)
+    ```
+
+    Set `skip_time=False` to assert on real wait durations.
 
 === "Java"
 
@@ -549,8 +554,15 @@ See [Authoring: Skip time in tests](authoring.md#skip-time-in-tests) for an over
 
 === "Python"
 
-    Not applicable. Configure with the `DURABLE_EXECUTION_TIME_SCALE` environment variable
-    and the `poll_interval` constructor argument.
+    ```python
+    DurableFunctionTestRunner(handler, skip_time=True, poll_interval=1.0)
+    ```
+
+    **Fields:**
+
+    - `skip_time` (optional) Use a virtual clock that skips modeled delays instantly.
+        Defaults to `True`.
+    - `poll_interval` (optional) Seconds between internal polling cycles. Defaults to `1.0`.
 
 === "Java"
 

--- a/docs/testing/authoring.md
+++ b/docs/testing/authoring.md
@@ -152,16 +152,15 @@ runner collapses these delays so tests finish in milliseconds.
 
 === "Python"
 
-    Set the `DURABLE_EXECUTION_TIME_SCALE` environment variable to a float that multiplies
-    `context.wait()` durations. Set it to `0` for instant waits, or to a small fraction such
-    as `0.01` to run waits at 100x speed. Step retry delays use the configured
-    `next_attempt_delay_seconds` at real wall-clock time, and the scale does not apply to
-    them. Keep retry delays short in tests, or configure a retry strategy with a low
-    `initial_delay_seconds`.
+    Pass `skip_time=True` to `DurableFunctionTestRunner` (the default). The runner uses a
+    virtual clock that advances instantly through modeled delays. Both `context.wait()`
+    durations and step retry delays complete in zero wall-clock time.
 
-    ```bash
-    DURABLE_EXECUTION_TIME_SCALE=0 pytest tests/my_wait_tests.py
+    ```python
+    runner = DurableFunctionTestRunner(handler=handler, skip_time=True)
     ```
+
+    Set `skip_time=False` to assert on real wait durations.
 
 === "Java"
 

--- a/docs/testing/workflow-patterns.md
+++ b/docs/testing/workflow-patterns.md
@@ -139,9 +139,9 @@ skipping. Each SDK handles this differently.
 
 === "Python"
 
-    Set the `DURABLE_EXECUTION_TIME_SCALE` environment variable to scale `context.wait()`
-    durations. Set it to `0.0` for instant waits, or to a small fraction such as `0.01` to
-    run waits at 100x speed. The scale does not apply to step retry delays.
+    `DurableFunctionTestRunner` defaults to `skip_time=True`, so the runner completes
+    `context.wait()` durations instantly via a virtual clock. The 24-hour wait resolves in
+    milliseconds.
 
     ```python
     --8<-- "examples/python/testing/examples/long-waits.py"

--- a/examples/python/testing/examples/long-waits.py
+++ b/examples/python/testing/examples/long-waits.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ["DURABLE_EXECUTION_TIME_SCALE"] = "0.0"
-
 from aws_durable_execution_sdk_python import DurableContext, durable_execution, durable_step
 from aws_durable_execution_sdk_python.types import StepContext
 from aws_durable_execution_sdk_python.config import Duration
@@ -22,7 +18,8 @@ def handler(event, context: DurableContext) -> str:
 
 
 def test_completes_with_long_wait():
-    runner = DurableFunctionTestRunner(handler=handler)
+    # skip_time=True is the default; the 24-hour wait completes instantly.
+    runner = DurableFunctionTestRunner(handler=handler, skip_time=True)
     with runner:
         result = runner.run(timeout=10)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Replace references to the `DURABLE_EXECUTION_TIME_SCALE` environment variable with the new `skip_time` parameter on `DurableFunctionTestRunner` in all Python testing docs and examples.

The Python SDK v2 ([aws/aws-durable-execution-sdk-python#523](https://github.com/aws/aws-durable-execution-sdk-python/pull/523)) replaces the env var time-scaling approach with a proper virtual clock (`SkipClock`). The test runner now
accepts `skip_time=True` (the default), which aligns Python with TypeScript (`skipTime`) and C# (`SkipTime`).

Blocked on: Python SDK v2 publishing to PyPI. Do not merge until v2 is released.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
