### PR TITLE
docs: explain operation nesting trade-offs

### DIFF
--- a/docs/patterns/best-practices/code-organization.md
+++ b/docs/patterns/best-practices/code-organization.md
@@ -105,9 +105,9 @@ intent clear.
 ## Run independent work concurrently
 
 Use `parallel` for a fixed number of named branches and `map` to iterate over a
-variable-length list. Both are durable so each branch checkpoints independently and
-survives Lambda timeouts or sandbox crashes, unlike language-specific constructs such as
-`Promise.all`, `asyncio.gather`, or `CompletableFuture`.
+variable-length list. Both checkpoint durable progress and survive Lambda timeouts or
+sandbox crashes, unlike language-specific constructs such as `Promise.all`,
+`asyncio.gather`, or `CompletableFuture`.
 
 === "TypeScript"
 

--- a/docs/sdk-reference/operations/map.md
+++ b/docs/sdk-reference/operations/map.md
@@ -110,7 +110,7 @@ Use map to apply the same operation to every item in a collection. Use
     - `func` A function called for each item. See [Map Function](#map-function).
     - `name` (optional) A name for the map operation. Omit it to infer one from the
         call site.
-    - `config` (optional) A `MapConfig` object.
+    - `config` (optional) A `MapConfig<TItem>` object.
     - `cancellationToken` (optional) A token linked with the SDK's workflow-shutdown
         signal, forwarded to `func`.
 
@@ -258,6 +258,7 @@ Use map to apply the same operation to every item in a collection. Use
         .serDes(SerDes)                // optional
         .nestingType(NestingType)      // optional
         .itemNamer(BiFunction<Object, Integer, String>)  // optional
+        .itemNamer(Class<I>, BiFunction<? super I, Integer, String>)  // optional
         .build()
     ```
 
@@ -270,18 +271,19 @@ Use map to apply the same operation to every item in a collection. Use
     - `nestingType` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
         [Nesting](#nesting).
     - `itemNamer` (optional) A function that returns a custom name for each item from the
-        item and its zero-based index. Java does not support `itemNamer` with
-        `NestingType.FLAT`.
+        item and its zero-based index. Pass the item type as the first argument to receive
+        the item strongly typed instead of as `Object`. Java does not support `itemNamer`
+        with `NestingType.FLAT`.
 
 === "C#"
 
     ```csharp
-    public sealed class MapConfig
+    public sealed class MapConfig<TItem>
     {
         public int? MaxConcurrency { get; set; }               // null = unlimited
-        public CompletionConfig CompletionConfig { get; set; } // default AllCompleted()
+        public CompletionConfig CompletionConfig { get; set; } // default AllSuccessful()
         public NestingType NestingType { get; set; }           // default Nested
-        public Func<object, int, string>? ItemNamer { get; set; }
+        public Func<TItem, int, string>? ItemNamer { get; set; }
     }
     ```
 
@@ -289,8 +291,9 @@ Use map to apply the same operation to every item in a collection. Use
 
     - `MaxConcurrency` (optional) Maximum items running at once. `null` (default) is
         unlimited; must be at least 1 when set.
-    - `CompletionConfig` (optional) When to stop. Default: `CompletionConfig.AllCompleted()`.
-        Every item runs regardless of per-item failures.
+    - `CompletionConfig` (optional) When to stop. Default: `CompletionConfig.AllSuccessful()`.
+        Any item failure completes the map with `FailureToleranceExceeded`. Set
+        `CompletionConfig.AllCompleted()` to run every item regardless of failures.
     - `NestingType` (optional) `NestingType.Nested` (default) or `NestingType.Flat`. See
         [Nesting](#nesting).
     - `ItemNamer` (optional) A function that returns a custom name for each item, given the
@@ -342,8 +345,8 @@ execution and the completion status of the result.
     Use the static factories or set the properties directly:
 
     ```csharp
-    CompletionConfig.AllCompleted()    // default for map: every item runs
-    CompletionConfig.AllSuccessful()   // ToleratedFailureCount = 0
+    CompletionConfig.AllSuccessful()   // default for map: ToleratedFailureCount = 0
+    CompletionConfig.AllCompleted()    // every item runs regardless of failures
     CompletionConfig.FirstSuccessful() // MinSuccessful = 1
 
     new CompletionConfig { MinSuccessful = count }
@@ -612,6 +615,14 @@ Name your map operations to make them easier to identify in logs and tests.
 
     Pass `name` as a keyword argument. Omit it or pass `None` to leave it unnamed.
 
+    Use `item_namer` in `MapConfig` to give each item a custom name:
+
+    ```python
+    config = MapConfig(item_namer=lambda order, index: f"order-{order['id']}")
+
+    context.map(orders, process_order, name="process-orders", config=config)
+    ```
+
 === "Java"
 
     ```java
@@ -620,6 +631,16 @@ Name your map operations to make them easier to identify in logs and tests.
 
     The name is always required in Java. The SDK derives each item's name from the operation
     name: `{name}-iteration-{index}`.
+
+    Use `itemNamer` in `MapConfig` to give each item a custom name:
+
+    ```java
+    var config = MapConfig.builder()
+            .itemNamer(Order.class, (order, index) -> "order-" + order.id())
+            .build();
+
+    context.map("process-orders", orders, ProcessedOrder.class, this::processOrder, config);
+    ```
 
 === "C#"
 
@@ -632,9 +653,9 @@ Name your map operations to make them easier to identify in logs and tests.
     Use `ItemNamer` in `MapConfig` to give each item a custom name:
 
     ```csharp
-    var config = new MapConfig
+    var config = new MapConfig<Order>
     {
-        ItemNamer = (item, index) => $"order-{((Order)item).Id}",
+        ItemNamer = (order, index) => $"order-{order.Id}",
     };
     ```
 
@@ -742,8 +763,8 @@ abandoned items, but cancellation is not guaranteed.
 
     | `CompletionConfig`                   | Early exit `CompletionReason` | Full completion `CompletionReason` |
     | ------------------------------------ | ----------------------------- | ---------------------------------- |
-    | `AllCompleted()` (default)           | n/a                           | `AllCompleted`                     |
-    | `AllSuccessful()`                    | `FailureToleranceExceeded`    | `AllCompleted`                     |
+    | `AllSuccessful()` (default)          | `FailureToleranceExceeded`    | `AllCompleted`                     |
+    | `AllCompleted()`                     | n/a                           | `AllCompleted`                     |
     | `FirstSuccessful()`                  | `MinSuccessfulReached`        | `AllCompleted`                     |
     | `MinSuccessful = N`                  | `MinSuccessfulReached`        | `AllCompleted`                     |
     | `ToleratedFailureCount = N`          | `FailureToleranceExceeded`    | `AllCompleted`                     |
@@ -832,8 +853,8 @@ checkpoint and records the item outcome with the parent map operation. Durable o
 inside an item still checkpoint in both modes.
 
 Items that have not completed when the map operation reaches its completion criteria
-receive no further checkpoint updates. The language-specific details below describe
-nested mode.
+receive no further checkpoint updates. Unless noted otherwise, the language-specific
+details below describe nested mode.
 
 === "TypeScript"
 

--- a/docs/sdk-reference/operations/map.md
+++ b/docs/sdk-reference/operations/map.md
@@ -5,8 +5,9 @@
 Map executes a function for each item in a collection concurrently. It manages
 concurrency, collects results as items complete, and checkpoints the outcome.
 
-Each item runs in its own [child context](child-context.md) and checkpoints its result
-independently as it completes.
+Each item runs in its own [child context](child-context.md). The default nested mode
+checkpoints that context and its result. Flat mode omits the per-item context checkpoint to
+reduce operation overhead.
 
 Use map to apply the same operation to every item in a collection. Use
 [parallel](parallel.md) instead to execute different operations concurrently.
@@ -202,6 +203,7 @@ Use map to apply the same operation to every item in a collection. Use
       completionConfig?: CompletionConfig;
       serdes?: Serdes<BatchResult<TResult>>;
       itemSerdes?: Serdes<TResult>;
+      summaryGenerator?: (result: BatchResult<TResult>) => string;
       nesting?: NestingType;
     }
     ```
@@ -214,19 +216,23 @@ Use map to apply the same operation to every item in a collection. Use
     - `completionConfig` (optional) When to stop. Default: wait for all items.
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual item results.
-    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. `FLAT`
-        reduces operation overhead by ~30% at the cost of lower observability.
+    - `summaryGenerator` (optional) A function invoked when the serialized `BatchResult`
+        exceeds 256KB. See [Checkpointing](#checkpointing).
+    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
 
 === "Python"
 
     ```python
     @dataclass(frozen=True)
-    class MapConfig:
+    class MapConfig(Generic[T]):
         max_concurrency: int | None = None
         completion_config: CompletionConfig = CompletionConfig()
         serdes: SerDes | None = None
         item_serdes: SerDes | None = None
         summary_generator: SummaryGenerator | None = None
+        nesting_type: NestingType = NestingType.NESTED
+        item_namer: Callable[[T, int], str] | None = None
     ```
 
     **Parameters:**
@@ -238,6 +244,10 @@ Use map to apply the same operation to every item in a collection. Use
     - `item_serdes` (optional) Custom `SerDes` for individual item results.
     - `summary_generator` (optional) A callable invoked when the serialized `BatchResult`
         exceeds 256KB. See [Checkpointing](#checkpointing).
+    - `nesting_type` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
+    - `item_namer` (optional) A deterministic callable that returns a custom name for each
+        item from the item and its zero-based index.
 
 === "Java"
 
@@ -246,6 +256,8 @@ Use map to apply the same operation to every item in a collection. Use
         .maxConcurrency(Integer)       // optional
         .completionConfig(CompletionConfig)  // optional
         .serDes(SerDes)                // optional
+        .nestingType(NestingType)      // optional
+        .itemNamer(BiFunction<Object, Integer, String>)  // optional
         .build()
     ```
 
@@ -255,6 +267,11 @@ Use map to apply the same operation to every item in a collection. Use
     - `completionConfig` (optional) When to stop. Default:
         `CompletionConfig.allCompleted()`.
     - `serDes` (optional) Custom `SerDes` for item results and the overall result.
+    - `nestingType` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
+    - `itemNamer` (optional) A function that returns a custom name for each item from the
+        item and its zero-based index. Java does not support `itemNamer` with
+        `NestingType.FLAT`.
 
 === "C#"
 
@@ -274,9 +291,8 @@ Use map to apply the same operation to every item in a collection. Use
         unlimited; must be at least 1 when set.
     - `CompletionConfig` (optional) When to stop. Default: `CompletionConfig.AllCompleted()`.
         Every item runs regardless of per-item failures.
-    - `NestingType` (optional) `NestingType.Nested` (default) or `NestingType.Flat`.
-        `Flat` records per-item results inline on the map operation instead of emitting a
-        per-item `CONTEXT` checkpoint.
+    - `NestingType` (optional) `NestingType.Nested` (default) or `NestingType.Flat`. See
+        [Nesting](#nesting).
     - `ItemNamer` (optional) A function that returns a custom name for each item, given the
         item and its zero-based index. Used in logs and traces. When `null` (default),
         items are named by index.
@@ -650,6 +666,22 @@ Configure map behavior using `MapConfig`:
     --8<-- "examples/csharp/operations/map/map-config.cs"
     ```
 
+## Nesting
+
+Nested mode is the default. The SDK records each item context as a separate `CONTEXT`
+operation and checkpoints the item result there. Each item appears separately in the
+execution history.
+
+In flat mode, the SDK uses a virtual context for each item and omits the per-item
+`CONTEXT` operation. Durable operations inside the map function still checkpoint and
+appear as children of the map operation. The SDK records the item outcome with the parent
+map operation.
+
+Use flat mode for maps with many items when each item performs few durable operations and
+you do not need each item represented separately in the execution history. Flat mode
+removes one checkpointed operation per item while preserving checkpoints for durable
+operations inside each item.
+
 ## Completion strategies
 
 `CompletionConfig` controls when the map operation completes. When the operation reaches
@@ -794,9 +826,14 @@ propagating it immediately. Other items continue running.
 
 ## Checkpointing
 
-Each item checkpoints its result on completion. Items that have not completed when the
-map operation reaches its completion criteria remain with status `STARTED` and will
-receive no further checkpoint updates.
+Checkpoint behavior depends on the nesting type. In nested mode, each item checkpoints
+its result in a per-item `CONTEXT` operation. In flat mode, the SDK omits that context
+checkpoint and records the item outcome with the parent map operation. Durable operations
+inside an item still checkpoint in both modes.
+
+Items that have not completed when the map operation reaches its completion criteria
+receive no further checkpoint updates. The language-specific details below describe
+nested mode.
 
 === "TypeScript"
 
@@ -868,11 +905,11 @@ receive no further checkpoint updates.
 
 === "C#"
 
-    The `IBatchResult` is reconstructed from the per-item child-context checkpoints. The
-    aggregate is never stored as a single serialized blob. On replay, the SDK reassembles the
-    `IBatchResult` from those individual checkpoints without re-executing completed items.
+    In nested mode, the SDK reconstructs `IBatchResult` from the per-item child-context
+    checkpoints without re-executing completed items. In flat mode, the SDK records item
+    results and errors inline on the parent map operation instead.
 
-    Each item's result is serialized with the `ILambdaSerializer` registered on
+    The SDK serializes results with the `ILambdaSerializer` registered on
     `ILambdaContext.Serializer`; there is no per-item summary generator to configure.
 
 ## Nesting map operations

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -896,8 +896,8 @@ checkpoint and records the branch outcome with the parent parallel operation. Du
 operations inside a branch still checkpoint in both modes.
 
 Branches that have not completed when the parallel operation reaches its completion
-criteria receive no further checkpoint updates. The language-specific details below
-describe nested mode.
+criteria receive no further checkpoint updates. Unless noted otherwise, the
+language-specific details below describe nested mode.
 
 === "TypeScript"
 

--- a/docs/sdk-reference/operations/parallel.md
+++ b/docs/sdk-reference/operations/parallel.md
@@ -5,8 +5,9 @@
 Parallel executes multiple operations concurrently. It manages concurrency, collects
 results as branches complete, and checkpoints the outcome.
 
-Each branch runs in its own [child context](child-context.md) and checkpoints its result
-independently as it completes.
+Each branch runs in its own [child context](child-context.md). The default nested mode
+checkpoints that context and its result. Flat mode omits the per-branch context checkpoint
+to reduce operation overhead.
 
 Use parallel to execute independent tasks concurrently. Use [map](map.md) instead to
 execute the same operation concurrently for each item in a collection.
@@ -218,6 +219,7 @@ execute the same operation concurrently for each item in a collection.
       completionConfig?: CompletionConfig;
       serdes?: Serdes<BatchResult<TResult>>;
       itemSerdes?: Serdes<TResult>;
+      summaryGenerator?: (result: BatchResult<TResult>) => string;
       nesting?: NestingType;
     }
     ```
@@ -228,8 +230,10 @@ execute the same operation concurrently for each item in a collection.
     - `completionConfig` (optional) When to stop. Default: wait for all branches.
     - `serdes` (optional) Custom `Serdes` for the `BatchResult`.
     - `itemSerdes` (optional) Custom `Serdes` for individual branch results.
-    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. `FLAT`
-        reduces operation overhead by ~30% at the cost of lower observability.
+    - `summaryGenerator` (optional) A function invoked when the serialized `BatchResult`
+        exceeds 256KB. See [Checkpointing](#checkpointing).
+    - `nesting` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
 
 === "Python"
 
@@ -241,6 +245,7 @@ execute the same operation concurrently for each item in a collection.
         serdes: SerDes | None = None
         item_serdes: SerDes | None = None
         summary_generator: SummaryGenerator | None = None
+        nesting_type: NestingType = NestingType.NESTED
     ```
 
     **Parameters:**
@@ -252,6 +257,8 @@ execute the same operation concurrently for each item in a collection.
     - `item_serdes` (optional) Custom `SerDes` for individual branch results.
     - `summary_generator` (optional) A callable invoked when the serialized `BatchResult`
         exceeds 256KB. See [Checkpointing](#checkpointing).
+    - `nesting_type` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
 
 === "Java"
 
@@ -259,6 +266,7 @@ execute the same operation concurrently for each item in a collection.
     ParallelConfig.builder()
         .maxConcurrency(Integer)      // optional
         .completionConfig(CompletionConfig)  // optional
+        .nestingType(NestingType)     // optional
         .build()
     ```
 
@@ -267,6 +275,8 @@ execute the same operation concurrently for each item in a collection.
     - `maxConcurrency` (optional) Maximum branches running at once. Default: unlimited.
     - `completionConfig` (optional) When to stop. Default:
         `CompletionConfig.allCompleted()`.
+    - `nestingType` (optional) `NestingType.NESTED` (default) or `NestingType.FLAT`. See
+        [Nesting](#nesting).
 
 === "C#"
 
@@ -285,13 +295,11 @@ execute the same operation concurrently for each item in a collection.
         unlimited. Must be at least 1 when set.
     - `CompletionConfig` (optional) When to stop. Default:
         `CompletionConfig.AllSuccessful()`.
-    - `NestingType` (optional) `NestingType.Nested` (default) or `NestingType.Flat`.
-        `Flat` records per-branch results inline on the parallel operation instead of
-        emitting a per-branch `CONTEXT` checkpoint.
+    - `NestingType` (optional) `NestingType.Nested` (default) or `NestingType.Flat`. See
+        [Nesting](#nesting).
 
-    The `IBatchResult` is reconstructed from per-branch checkpoints, which are serialized
-    with the `ILambdaSerializer` registered on `ILambdaContext.Serializer`; there is no
-    per-operation serializer slot.
+    The SDK serializes results with the `ILambdaSerializer` registered on
+    `ILambdaContext.Serializer`; there is no per-operation serializer slot.
 
 ### CompletionConfig
 
@@ -710,6 +718,22 @@ Configure parallel behavior using `ParallelConfig`:
     --8<-- "examples/csharp/operations/parallel/parallel-config.cs"
     ```
 
+## Nesting
+
+Nested mode is the default. The SDK records each branch context as a separate `CONTEXT`
+operation and checkpoints the branch result there. Each branch appears separately in the
+execution history.
+
+In flat mode, the SDK uses a virtual context for each branch and omits the per-branch
+`CONTEXT` operation. Durable operations inside the branch still checkpoint and appear as
+children of the parallel operation. The SDK records the branch outcome with the parent
+parallel operation.
+
+Use flat mode for parallel operations with many branches when each branch performs few
+durable operations and you do not need each branch represented separately in the
+execution history. Flat mode removes one checkpointed operation per branch while
+preserving checkpoints for durable operations inside each branch.
+
 ## Completion strategies
 
 `CompletionConfig` controls when the parallel operation completes. When the operation
@@ -866,9 +890,14 @@ propagating it immediately. Other branches continue running.
 
 ## Checkpointing
 
-Each branch checkpoints its result on completion. Branches that have not completed yet
-when the parallel operation reaches its completion criteria remain with status `STARTED`
-and will receive no further checkpoint updates.
+Checkpoint behavior depends on the nesting type. In nested mode, each branch checkpoints
+its result in a per-branch `CONTEXT` operation. In flat mode, the SDK omits that context
+checkpoint and records the branch outcome with the parent parallel operation. Durable
+operations inside a branch still checkpoint in both modes.
+
+Branches that have not completed when the parallel operation reaches its completion
+criteria receive no further checkpoint updates. The language-specific details below
+describe nested mode.
 
 === "TypeScript"
 
@@ -938,10 +967,10 @@ and will receive no further checkpoint updates.
 
 === "C#"
 
-    Each branch checkpoints its result as it completes. The `IBatchResult` is reconstructed
-    from those per-branch checkpoints rather than stored as a single aggregate blob, so the
-    SDK reassembles it on replay from the individual branch results. Per-branch payloads are
-    serialized with the `ILambdaSerializer` registered on `ILambdaContext.Serializer`.
+    In nested mode, the SDK reconstructs `IBatchResult` from per-branch checkpoints.
+    In flat mode, the SDK records branch results and errors inline on the parent parallel
+    operation instead. The SDK serializes results with the `ILambdaSerializer` registered
+    on `ILambdaContext.Serializer`.
 
 ## Nesting parallel operations
 

--- a/examples/csharp/operations/map/completion-config.cs
+++ b/examples/csharp/operations/map/completion-config.cs
@@ -11,7 +11,7 @@ public class CompletionConfigExample
     private async Task<IReadOnlyList<string>> Workflow(
         ItemEvent input, IDurableContext ctx)
     {
-        var config = new MapConfig
+        var config = new MapConfig<string>
         {
             CompletionConfig = new CompletionConfig { MinSuccessful = 3 },
         };

--- a/examples/csharp/operations/map/map-config.cs
+++ b/examples/csharp/operations/map/map-config.cs
@@ -13,7 +13,7 @@ public class MapConfigExample
     private async Task<IReadOnlyList<string>> Workflow(
         UrlEvent input, IDurableContext ctx)
     {
-        var config = new MapConfig
+        var config = new MapConfig<string>
         {
             MaxConcurrency = 5,
             CompletionConfig = new CompletionConfig { ToleratedFailureCount = 2 },

--- a/examples/csharp/operations/map/map-config.cs
+++ b/examples/csharp/operations/map/map-config.cs
@@ -17,6 +17,7 @@ public class MapConfigExample
         {
             MaxConcurrency = 5,
             CompletionConfig = new CompletionConfig { ToleratedFailureCount = 2 },
+            NestingType = NestingType.Flat,
         };
 
         IBatchResult<string> result = await ctx.MapAsync(

--- a/examples/csharp/operations/map/map-signature.cs
+++ b/examples/csharp/operations/map/map-signature.cs
@@ -2,5 +2,5 @@ Task<IBatchResult<TResult>> MapAsync<TItem, TResult>(
     IReadOnlyList<TItem> items,
     Func<IDurableContext, TItem, int, IReadOnlyList<TItem>, CancellationToken, Task<TResult>> func,
     string? name = null,
-    MapConfig? config = null,
+    MapConfig<TItem>? config = null,
     CancellationToken cancellationToken = default);

--- a/examples/csharp/operations/parallel/parallel-config.cs
+++ b/examples/csharp/operations/parallel/parallel-config.cs
@@ -13,6 +13,7 @@ public class ParallelConfigExample
         {
             MaxConcurrency = 2,
             CompletionConfig = CompletionConfig.FirstSuccessful(),
+            NestingType = NestingType.Flat,
         };
 
         IBatchResult<string> result = await ctx.ParallelAsync(

--- a/examples/csharp/patterns/code-organization/parallelism.cs
+++ b/examples/csharp/patterns/code-organization/parallelism.cs
@@ -29,7 +29,7 @@ public class ParallelismExample
             async (itemCtx, item, index, items, ct) =>
                 await itemCtx.StepAsync(async (_, _) => Process(item), name: $"process-{index}"),
             name: "process-items",
-            config: new MapConfig { MaxConcurrency = 10 });
+            config: new MapConfig<string> { MaxConcurrency = 10 });
 
         return enrich.GetResults().Concat(processed.GetResults()).ToList();
     }

--- a/examples/csharp/sdk-reference/serialization/MapConfigExample.cs
+++ b/examples/csharp/sdk-reference/serialization/MapConfigExample.cs
@@ -12,7 +12,7 @@ public class MapConfigExample
         // MapConfig has no serializer slot. Each item result is serialized with the
         // ILambdaSerializer registered on ILambdaContext.Serializer. To customize
         // serialization, register a custom ILambdaSerializer at the host boundary.
-        var config = new MapConfig
+        var config = new MapConfig<string>
         {
             MaxConcurrency = 3,
         };

--- a/examples/java/operations/map/map-config.java
+++ b/examples/java/operations/map/map-config.java
@@ -27,7 +27,9 @@ public class MapConfigExample extends DurableHandler<List<String>, List<String>>
                 String.class,
                 (url, index, ctx) -> ctx.step("fetch-" + index, String.class, s -> {
                     var request = HttpRequest.newBuilder(URI.create(url)).build();
-                    return HTTP.send(request, HttpResponse.BodyHandlers.ofString()).body();
+                    return HTTP.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                            .join()
+                            .body();
                 }),
                 config);
 

--- a/examples/java/operations/map/map-config.java
+++ b/examples/java/operations/map/map-config.java
@@ -7,6 +7,7 @@ import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.config.CompletionConfig;
 import software.amazon.lambda.durable.config.MapConfig;
+import software.amazon.lambda.durable.config.NestingType;
 import software.amazon.lambda.durable.model.MapResult;
 
 public class MapConfigExample extends DurableHandler<List<String>, List<String>> {
@@ -17,6 +18,7 @@ public class MapConfigExample extends DurableHandler<List<String>, List<String>>
         var config = MapConfig.builder()
                 .maxConcurrency(5)
                 .completionConfig(CompletionConfig.toleratedFailureCount(2))
+                .nestingType(NestingType.FLAT)
                 .build();
 
         MapResult<String> result = context.map(

--- a/examples/java/operations/parallel/parallel-config.java
+++ b/examples/java/operations/parallel/parallel-config.java
@@ -1,6 +1,7 @@
 import software.amazon.lambda.durable.DurableContext;
 import software.amazon.lambda.durable.DurableHandler;
 import software.amazon.lambda.durable.config.CompletionConfig;
+import software.amazon.lambda.durable.config.NestingType;
 import software.amazon.lambda.durable.config.ParallelConfig;
 import software.amazon.lambda.durable.model.ParallelResult;
 
@@ -10,6 +11,7 @@ public class ParallelConfigExample extends DurableHandler<Void, ParallelResult> 
         var config = ParallelConfig.builder()
                 .maxConcurrency(2)
                 .completionConfig(CompletionConfig.firstSuccessful())
+                .nestingType(NestingType.FLAT)
                 .build();
 
         try (var parallel = context.parallel("fetch-data", config)) {

--- a/examples/python/operations/map/map-config.py
+++ b/examples/python/operations/map/map-config.py
@@ -35,4 +35,4 @@ def handler(event: dict, context: DurableContext) -> list[str]:
         name="fetch-urls",
         config=config,
     )
-    return result.to_dict()
+    return result.get_results()

--- a/examples/python/operations/map/map-config.py
+++ b/examples/python/operations/map/map-config.py
@@ -5,7 +5,11 @@ from aws_durable_execution_sdk_python import (
     DurableContext,
     durable_execution,
 )
-from aws_durable_execution_sdk_python.config import CompletionConfig, MapConfig
+from aws_durable_execution_sdk_python.config import (
+    CompletionConfig,
+    MapConfig,
+    NestingType,
+)
 
 
 def fetch_url(
@@ -23,6 +27,7 @@ def handler(event: dict, context: DurableContext) -> list[str]:
     config = MapConfig(
         max_concurrency=5,
         completion_config=CompletionConfig(tolerated_failure_count=2),
+        nesting_type=NestingType.FLAT,
     )
     result: BatchResult[str] = context.map(
         event["urls"],

--- a/examples/python/operations/map/named-map.py
+++ b/examples/python/operations/map/named-map.py
@@ -19,4 +19,4 @@ def handler(event: dict, context: DurableContext) -> list[str]:
         process_user,
         name="process-users",
     )
-    return result.to_dict()
+    return result.get_results()

--- a/examples/python/operations/parallel/parallel-config.py
+++ b/examples/python/operations/parallel/parallel-config.py
@@ -3,7 +3,11 @@ from aws_durable_execution_sdk_python import (
     DurableContext,
     durable_execution,
 )
-from aws_durable_execution_sdk_python.config import CompletionConfig, ParallelConfig
+from aws_durable_execution_sdk_python.config import (
+    CompletionConfig,
+    NestingType,
+    ParallelConfig,
+)
 
 
 def try_primary(ctx: DurableContext) -> str:
@@ -23,6 +27,7 @@ def handler(event: dict, context: DurableContext) -> str | None:
     config = ParallelConfig(
         max_concurrency=2,
         completion_config=CompletionConfig.first_successful(),
+        nesting_type=NestingType.FLAT,
     )
     result: BatchResult[str] = context.parallel(
         [try_primary, try_secondary, try_cache],

--- a/examples/typescript/operations/map/map-config.ts
+++ b/examples/typescript/operations/map/map-config.ts
@@ -1,6 +1,7 @@
 import {
   BatchResult,
   DurableContext,
+  NestingType,
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
@@ -17,6 +18,7 @@ export const handler = withDurableExecution(
       {
         maxConcurrency: 5,
         completionConfig: { toleratedFailureCount: 2 },
+        nesting: NestingType.FLAT,
       },
     );
 

--- a/examples/typescript/operations/parallel/parallel-config.ts
+++ b/examples/typescript/operations/parallel/parallel-config.ts
@@ -1,6 +1,7 @@
 import {
   BatchResult,
   DurableContext,
+  NestingType,
   withDurableExecution,
 } from "@aws/durable-execution-sdk-js";
 
@@ -16,6 +17,7 @@ export const handler = withDurableExecution(
       {
         maxConcurrency: 2,
         completionConfig: { minSuccessful: 1 },
+        nesting: NestingType.FLAT,
       },
     );
 


### PR DESCRIPTION
## Summary

- Document nested and flat map and parallel behavior across TypeScript,
  Python, Java, and C#.
- Explain the observability, checkpoint, cost, and scale trade-offs.
- Update equivalent nesting examples for all four SDKs.
- Document TypeScript `summaryGenerator` configuration for map and parallel.
- Complete Python and Java map item-namer coverage, including Java's flat
  nesting restriction.
- Reconcile checkpointing guidance across the affected pages.

Closes #188.
Closes #244.
Closes #245.

Supersedes #194. Thanks @lyushher for the initial documentation and
discussion that shaped this update.

## Validation

- `mdformat --check docs/`
- `codespell docs/`
- `python3 scripts/vendor_mermaid.py --check`
- `python3 scripts/vendor_glightbox.py --check`
- `python3 scripts/check_example_refs.py`
- `zensical build --clean`
- Hidden-character scan
- Python example syntax checks
- Four-language nesting configuration smoke checks
- `git diff --check`

An independent review completed with no actionable findings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
