### PR TITLE
docs(otel): align guidance with SDK changes

### DIFF
--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -9,11 +9,18 @@ boundaries.
 A durable execution can run across many Lambda invocations. The plugin exposes
 two correlated views:
 
-- A durable `Workflow` trace uses stable, execution-scoped trace and span IDs.
-    Its root span is exported when the execution reaches a terminal status.
-- Each `Invocation` span belongs to the current Lambda or application trace.
-    With ADOT, it inherits the ambient Lambda trace. Without an ambient parent,
-    the configured provider generates a new invocation trace.
+- **Workflow view**: One execution-scoped `Workflow` trace uses stable trace and
+    span IDs across all Lambda invocations. With `ExecutionOtelPlugin`, it
+    contains the operation and attempt hierarchy. With `InvocationOtelPlugin`,
+    it acts as a correlation root that operation and attempt spans link to. The
+    `Workflow` root span is exported when the execution reaches a terminal
+    status.
+- **Invocation view**: Each Lambda invocation produces an `Invocation` span in
+    the current Lambda or application trace. With `InvocationOtelPlugin`, it
+    parents the operations and attempts from that invocation. With
+    `ExecutionOtelPlugin`, those spans remain in the Workflow view and link to
+    the `Invocation` span instead. The invocation view is exported when each
+    Lambda invocation ends.
 
 Span links connect the two views. The deterministic ID overrides are scoped to
 spans created by the plugin, so unrelated OpenTelemetry instrumentation

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -26,11 +26,11 @@ Span links connect the two views. The deterministic ID overrides are scoped to
 spans created by the plugin, so unrelated OpenTelemetry instrumentation
 continues to use the provider's normal ID generator.
 
-The plugin no longer auto-configures an OpenTelemetry export pipeline. It uses
-the global provider by default. For an application-owned pipeline, you must
-supply the provider, provider factory, or provider builder and configure its
-processors, exporter, sampling, resources, propagators, and library
-instrumentation.
+Provider and export-pipeline configuration are external to the plugins. By
+default, each plugin uses the global provider. For an application-owned
+pipeline, supply the provider, provider factory, or provider builder and
+configure its processors, exporter, sampling, resources, propagators, and
+library instrumentation.
 
 Some names on this page keep the X-Ray label, such as the X-Ray trace header and
 the `awsxray` collector exporter, but the resulting traces are available in

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -1,19 +1,33 @@
 # OpenTelemetry
 
 The OpenTelemetry plugin instruments a durable execution and emits distributed
-traces to any OTLP backend, such as Amazon CloudWatch. It builds on
-the [plugin interface](plugins.md): you register it in your handler
-configuration, and it opens spans at the invocation, operation, and attempt
-boundaries as the execution runs.
+traces to any OpenTelemetry backend, such as Amazon CloudWatch. It builds on the
+[plugin interface](plugins.md): you register it in your handler configuration,
+and it opens spans at the workflow, invocation, operation, and attempt
+boundaries.
 
-A durable execution runs across many Lambda invocations. The plugin derives
-deterministic trace and span IDs from the execution ARN, and from the X-Ray
-trace header when one is present, so the spans from every invocation join a
-single trace. Without deterministic IDs, each invocation would produce its own
-disconnected trace.
+A durable execution can run across many Lambda invocations. The plugin exposes
+two correlated views:
 
-Some names on this page keep the X-Ray label (for example the X-Ray trace
-header and the `awsxray` collector exporter), but your spans land in CloudWatch.
+- A durable `Workflow` trace uses stable, execution-scoped trace and span IDs.
+    Its root span is exported when the execution reaches a terminal status.
+- Each `Invocation` span belongs to the current Lambda or application trace.
+    With ADOT, it inherits the ambient Lambda trace. Without an ambient parent,
+    the configured provider generates a new invocation trace.
+
+Span links connect the two views. The deterministic ID overrides are scoped to
+spans created by the plugin, so unrelated OpenTelemetry instrumentation
+continues to use the provider's normal ID generator.
+
+The plugin no longer auto-configures an OpenTelemetry export pipeline. It uses
+the global provider by default. For an application-owned pipeline, you must
+supply the provider, provider factory, or provider builder and configure its
+processors, exporter, sampling, resources, propagators, and library
+instrumentation.
+
+Some names on this page keep the X-Ray label, such as the X-Ray trace header and
+the `awsxray` collector exporter, but the resulting traces are available in
+CloudWatch.
 
 !!! note "Experimental feature"
 
@@ -35,10 +49,25 @@ header and the `awsxray` collector exporter), but your spans land in CloudWatch.
     npm install @aws/durable-execution-sdk-js-otel
     ```
 
+    The TypeScript plugin requires Node.js 22 or later.
+
 === "Python"
+
+    When a Lambda telemetry layer supplies the OpenTelemetry libraries:
 
     ```bash
     pip install aws-durable-execution-sdk-python-otel
+    ```
+
+    The base package intentionally does not install OpenTelemetry libraries,
+    which prevents function dependencies from shadowing the version-aligned
+    libraries in the layer.
+
+    When the application configures its own provider, install the `standalone`
+    extra:
+
+    ```bash
+    pip install "aws-durable-execution-sdk-python-otel[standalone]"
     ```
 
 === "Java"
@@ -51,23 +80,26 @@ header and the `awsxray` collector exporter), but your spans land in CloudWatch.
     </dependency>
     ```
 
+    Add an exporter dependency when the application supplies its own tracer
+    provider. The ADOT Java agent supplies the export pipeline for the no-arg
+    plugin constructors.
+
 ## The two plugins
 
-The package ships two plugins. Both correlate a whole durable execution into a
-single trace with deterministic IDs, and both emit a `Workflow` root span for the
-execution. They differ in where they root the invocation view and when they
-export the root span. You register exactly one of them.
+Both plugins emit the same span types and a deterministic `Workflow` root span.
+They differ in the parent of operation spans and when those spans become
+visible. Register exactly one of them.
 
 ### ExecutionOtelPlugin
 
-`ExecutionOtelPlugin` opens a synthetic `Workflow` span as the trace root. Every
-invocation span and operation span nests under it. The plugin exports the
-`Workflow` span only when the execution reaches a terminal status, so an
-execution that is still running does not leave a dangling root span, but you also
-cannot watch the trace in progress, and a span held open for hours can exceed the
-ingestion limits of some observability platforms. Choose this plugin for short
-executions, or when you want one unified trace per execution with the workflow as
-the logical root.
+`ExecutionOtelPlugin` provides a workflow-centered view. Operation spans are
+children of the `Workflow` span and link to the `Invocation` span that observed
+them. The `Workflow` span is exported only when the execution reaches a terminal
+status. An operation that suspends is also left unexported until it completes.
+
+Choose this plugin for shorter executions or when the durable workflow hierarchy
+is more important than seeing each invocation as it completes. Long-open
+workflow spans can exceed the ingestion limits of some observability platforms.
 
 === "TypeScript"
 
@@ -87,38 +119,47 @@ the logical root.
     --8<-- "examples/java/sdk-reference/observability/opentelemetry/execution-plugin.java"
     ```
 
-The trace you see groups every invocation of the execution under one `Workflow`
-root:
+With an ADOT or global provider, the workflow and invocation views are separate
+traces:
 
 ```text
-Workflow                              (root, exported on terminal status)
-├── Invocation #1
-├── Invocation #2
-├── Operation: fetch-data  (STEP)      -> link to Invocation #1
-│   └── Attempt: fetch-data attempt 1  -> link to Invocation #1
-├── Operation: cooldown    (WAIT)      -> link to Invocation #2
-└── Operation: process     (STEP)      -> link to Invocation #2
-    └── Attempt: process attempt 1     -> link to Invocation #2
+Durable workflow trace:
+Workflow                              (root; exported on terminal status)
+|-- Operation: fetch-data  (STEP)      -> link to Invocation #1
+|   `-- Attempt: fetch-data attempt 1  -> link to Invocation #1
+|-- Operation: cooldown    (WAIT)      -> link to Invocation #2
+`-- Operation: process     (STEP)      -> link to Invocation #2
+    `-- Attempt: process attempt 1     -> link to Invocation #2
+
+Ambient Lambda trace #1:
+Lambda invocation
+`-- Invocation #1
+
+Ambient Lambda trace #2:
+Lambda invocation
+`-- Invocation #2
 ```
 
-Operation spans link to the invocation span that produced them, so you can tell
-which invocation ran each operation even though the operations root under the
-`Workflow` span.
+The operation links identify which invocation ran each part of the workflow.
+The invocation spans are not children of `Workflow`.
+
+!!! note "TypeScript application-owned provider"
+
+    When TypeScript `ExecutionOtelPlugin` uses `tracerProviderFactory` and no
+    ambient trace exists, its `Invocation` span is created under `Workflow`.
+    The global-provider and ADOT path keeps the invocation in the ambient Lambda
+    trace as shown above.
 
 ### InvocationOtelPlugin
 
-`InvocationOtelPlugin` keeps the trace invocation-rooted. It opens a parentless
-`Workflow` root span in both provider modes, keyed to a deterministic ID from the
-execution ARN and ended only at the terminal invocation. The invocation span is
-not a child of that `Workflow` span. Each invocation span roots its own operation
-and attempt spans, and those spans carry a link to the `Workflow` span for
-execution-scoped correlation.
+`InvocationOtelPlugin` provides an invocation-centered view. Each `Invocation`
+span parents the operation and attempt spans emitted during that Lambda
+invocation. Those operation and attempt spans link to the deterministic
+`Workflow` span for execution-scoped correlation.
 
-The plugin exports each invocation span as that invocation ends. A Lambda
-invocation lasts at most 15 minutes, so spans stay within platform limits and
-appear as the execution runs, which renders reliably across most platforms.
-Choose this plugin for long-running executions, or when you want per-invocation
-traces that still correlate to one workflow and to view an execution in progress.
+The plugin exports an invocation and its child spans when that invocation ends.
+Choose it for long-running executions or when you want traces to appear as the
+execution progresses.
 
 === "TypeScript"
 
@@ -138,54 +179,52 @@ traces that still correlate to one workflow and to view an execution in progress
     --8<-- "examples/java/sdk-reference/observability/opentelemetry/invocation-plugin.java"
     ```
 
-The `Workflow` span is a parentless root that operation and attempt spans link
-to. Each Lambda invocation roots its own view. The example above suspends at the
-`cooldown` wait, so it runs across two invocations, and the wait produces a span
-in each:
+For an execution that suspends at a wait, the traces resemble:
 
 ```text
-Workflow                              (parentless root; deterministic ID; ended at the terminal invocation)
+Durable workflow trace:
+Workflow                              (root; exported on terminal status)
 
-Invocation #1                         (per-invocation root; not nested under Workflow)
-├── Operation: fetch-data  (STEP)      -> link to Workflow
-│   └── Attempt: fetch-data attempt 1  -> link to Workflow
-└── Operation: cooldown    (WAIT)      -> link to Workflow      (wait starts; execution suspends)
+Ambient Lambda trace #1:
+Lambda invocation
+`-- Invocation #1
+    |-- Operation: fetch-data  (STEP)      -> link to Workflow
+    |   `-- Attempt: fetch-data attempt 1  -> link to Workflow
+    `-- Operation: cooldown    (WAIT)      -> link to Workflow
 
-Invocation #2                         (per-invocation root; resumes after the wait)
-├── Operation: cooldown    (WAIT)      -> link to the first cooldown span, and to Workflow
-└── Operation: process     (STEP)      -> link to Workflow
-    └── Attempt: process attempt 1     -> link to Workflow
+Ambient Lambda trace #2:
+Lambda invocation
+`-- Invocation #2
+    |-- Operation: cooldown    (WAIT)      -> link to Workflow
+    `-- Operation: process     (STEP)      -> link to Workflow
+        `-- Attempt: process attempt 1     -> link to Workflow
 ```
 
-An operation that completes in a later invocation, such as an invoke, wait, or
-callback, can appear as more than one span across invocations. Each later span
-carries a link back to the first span for that operation, so a retry or a resumed
-wait relates to its first appearance. CloudWatch does not yet visualize these
-links.
+An operation that crosses an invocation boundary can produce more than one
+span. The portable correlation point is the `Workflow` link. Do not rely on a
+later segment containing a link to an earlier operation span because the SDK
+does not checkpoint that OpenTelemetry span context.
 
 ### Choosing a plugin
 
-The `ExecutionOtelPlugin` and `InvocationOtelPlugin` sections above cover when to
-choose each. This table summarizes the differences. For both plugins, your
-observability platform's quotas and limits apply.
+For both plugins, your observability platform's quotas and limits apply.
 
-| Consideration          | ExecutionOtelPlugin                                               | InvocationOtelPlugin                                                             |
-| ---------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Trace root             | Synthetic `Workflow` span                                         | Invocation span; a `Workflow` span is also emitted and linked from operations    |
-| Root span export       | Only when the execution completes                                 | Each invocation span exports when that invocation ends                           |
-| Operation span         | Exported once, in its entirety, when complete                     | Can appear under multiple invocation spans                                       |
-| In-progress visibility | Fragmented until the execution finishes                           | Each invocation appears as it completes                                          |
-| Better for             | Short executions                                                  | Longer-running executions, or watching one in progress                           |
-| Platform compatibility | A long-open root span can exceed some platforms' ingestion limits | Invocation spans stay within the 15-minute Lambda limit, so they render reliably |
+| Consideration          | ExecutionOtelPlugin                                       | InvocationOtelPlugin                                 |
+| ---------------------- | --------------------------------------------------------- | ---------------------------------------------------- |
+| Operation parent       | Deterministic `Workflow` trace                            | Current `Invocation` trace                           |
+| Cross-view link        | Operation or attempt to `Invocation`                      | Operation or attempt to `Workflow`                   |
+| Workflow export        | On terminal execution status                              | On terminal execution status                         |
+| Operation visibility   | When the operation completes                              | At each invocation boundary                          |
+| In-progress visibility | Limited until operations and the execution complete       | Each invocation appears as it completes              |
+| Better for             | Short executions and a workflow-centered hierarchy        | Long executions and an invocation-centered hierarchy |
+| Platform compatibility | Long-open spans can exceed platform ingestion time limits | Spans stay within the Lambda invocation time limit   |
 
 ## Span structure and attributes
 
-Both plugins emit a `Workflow` root span for the whole execution. Beneath it
-(ExecutionOtelPlugin) or linked to it (InvocationOtelPlugin) sit three levels of
-spans. An invocation span covers one Lambda invocation. Operation spans nest one
-per durable operation, such as a step, wait, or child invoke. Attempt spans nest
-one per try under a step or wait-for-condition operation, so retries appear as
-sibling spans.
+Both plugins emit four span types. An invocation span covers one Lambda
+invocation. Operation spans cover durable operations such as steps, waits, child
+contexts, callbacks, and chained invokes. Attempt spans cover user function
+attempts, so retries appear as sibling spans.
 
 | Span       | Attributes                                                                                                                                                   |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -194,26 +233,25 @@ sibling spans.
 | Operation  | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.operation.subtype`, `durable.operation.status` |
 | Attempt    | `durable.execution.arn`, `durable.operation.id`, `durable.operation.type`, `durable.operation.name`, `durable.attempt.number`, `durable.attempt.outcome`     |
 
-`durable.operation.type` is one of `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
-or `CALLBACK`. A `CONTEXT` operation (a child context) gets an operation span but
-no attempt span, since attempt spans apply only to steps and wait-for-conditions.
+`durable.operation.type` includes `STEP`, `WAIT`, `CONTEXT`, `CHAINED_INVOKE`,
+and `CALLBACK`. A `CONTEXT` operation gets an operation span but not a separate
+attempt span.
 
 ## Deploy with the ADOT layer
 
-The AWS Distro for OpenTelemetry (ADOT) Lambda layer bundles OpenTelemetry
-auto-instrumentation and a collector extension. The collector listens on
-`localhost:4318` and forwards spans to CloudWatch. Add the layer,
-enable active tracing so the runtime populates the `_X_AMZN_TRACE_ID`
-header the plugin reads, and grant the function's role the
-`AWSXRayDaemonWriteAccess` managed policy.
+The AWS Distro for OpenTelemetry (ADOT) Lambda layer supplies a global provider,
+auto-instrumentation, and a collector extension. Add the language-specific
+layer, set `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument`, enable active tracing
+so invocation spans can inherit the Lambda trace, and grant the function role
+the `AWSXRayDaemonWriteAccess` managed policy.
+
+The no-arg plugin constructors use the global provider. You do not need a
+provider option.
 
 === "TypeScript"
 
-    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument` to activate the
-    layer's instrumentation, and construct the plugin with
-    `useDefaultTracerProvider: true` so it uses the layer's global tracer
-    provider. Find the current ADOT JavaScript layer ARN for your region and
-    architecture in the
+    Find the current ADOT JavaScript layer ARN for your region and architecture
+    in the
     [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
 
     ```yaml
@@ -234,15 +272,15 @@ header the plugin reads, and grant the function's role the
     ```
 
     ```typescript
-    new ExecutionOtelPlugin({ useDefaultTracerProvider: true });
+    new ExecutionOtelPlugin();
     // or
-    new InvocationOtelPlugin({ useDefaultTracerProvider: true });
+    new InvocationOtelPlugin();
     ```
 
 === "Python"
 
-    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument`. Find the current
-    layer ARN for your region and architecture in the
+    Find the current ADOT Python layer ARN for your region and architecture in
+    the
     [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
 
     ```yaml
@@ -262,20 +300,21 @@ header the plugin reads, and grant the function's role the
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
     ```
 
-    `InvocationOtelPlugin()` uses the layer's global provider by default.
-    `ExecutionOtelPlugin(OtelPluginConfig(use_default_tracer_provider=True))`
-    does the same.
+    ```python
+    ExecutionOtelPlugin()
+    # or
+    InvocationOtelPlugin()
+    ```
 
 === "Java"
 
-    Set `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-instrument` to activate the ADOT
-    Java agent, and register the plugin jar as an agent extension through
-    `OTEL_JAVAAGENT_EXTENSIONS` (the path to the bundled plugin jar) so its SPI
-    installs deterministic ID generation into the agent's provider. Then
-    construct either plugin with the no-arg constructor, which reads the agent's
-    global provider. Find the current ADOT Java layer ARN for your region and
-    architecture in the
-    [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda#adot-lambda-layer-arns).
+    The Java agent must also load the plugin JAR as an agent extension so its
+    auto-configuration SPI can scope deterministic ID generation to durable
+    spans. Package the JAR in a layer under `java/lib`, then point
+    `OTEL_JAVAAGENT_EXTENSIONS` to the deployed path.
+
+    Find the current ADOT Java layer ARN in the
+    [ADOT Java instrumentation releases](https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest).
 
     ```yaml
     MyFunction:
@@ -285,10 +324,11 @@ header the plugin reads, and grant the function's role the
         Handler: com.example.ExampleHandler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<adot-java-layer>:<version>
+          - <otel-plugin-layer-arn>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
-            OTEL_JAVAAGENT_EXTENSIONS: /opt/otel-plugin-extension.jar
+            OTEL_JAVAAGENT_EXTENSIONS: /opt/java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar
         Tracing: Active
         Policies:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
@@ -296,16 +336,30 @@ header the plugin reads, and grant the function's role the
     ```
 
     ```java
-    new ExecutionOtelPlugin();   // uses the agent's global provider
-    new InvocationOtelPlugin();  // uses the agent's global provider
+    new ExecutionOtelPlugin();
+    // or
+    new InvocationOtelPlugin();
     ```
+
+    To load the plugin from the layer without registering it in handler code,
+    also set `DURABLE_EXECUTION_PLUGINS` to `otel-execution` or
+    `otel-invocation`.
+
+If the global SDK provider is not ready at plugin construction, the plugins
+retry provider resolution at invocation start. Python and Java disable
+telemetry for that invocation when a compatible SDK provider is still
+unavailable, then retry on the next invocation. TypeScript emits no exported
+spans when no SDK provider is registered. If TypeScript finds a registered
+tracer whose runtime ID generator is incompatible, it logs the problem once
+and continues without deterministic durable IDs.
 
 ## Deploy with the community collector layer
 
-The OpenTelemetry community collector layer runs a collector extension only,
-without auto-instrumentation. The plugin
-creates its own tracer provider and exports spans to the collector on
-`localhost:4318`. Do not set `AWS_LAMBDA_EXEC_WRAPPER` with this layer.
+The OpenTelemetry community collector layer runs a collector extension without
+auto-instrumentation. Do not set `AWS_LAMBDA_EXEC_WRAPPER`. Configure an
+application-owned provider that exports OTLP HTTP spans to
+`http://localhost:4318/v1/traces`, and pass that provider to the plugin using the
+language-specific API below.
 
 Include a `collector.yaml` in your function bundle and set
 `OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path:
@@ -326,178 +380,297 @@ service:
       exporters: [awsxray]
 ```
 
-Routing spans through a collector also lets you export to a third-party platform
-such as Datadog, Honeycomb, or Grafana by changing the collector's exporter,
-without first sending them to CloudWatch. Check https://github.com/open-telemetry/opentelemetry-lambda/releases
-for the most recent Collector layer releases.
+Add the collector layer and configuration variable:
+
+```yaml
+Layers:
+  - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
+Environment:
+  Variables:
+    OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+```
+
+See the
+[OpenTelemetry Lambda releases](https://github.com/open-telemetry/opentelemetry-lambda/releases)
+for current collector layer releases.
 
 === "TypeScript"
 
-    Construct either plugin with `useDefaultTracerProvider: false` (the default),
-    so it auto-creates a provider that exports to `localhost:4318`.
+    `tracerProviderFactory` receives a function that creates the plugin's scoped
+    deterministic ID generator. Use it when constructing the provider. The
+    application owns provider registration and shutdown.
 
-    ```yaml
-    Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
-    Environment:
-      Variables:
-        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```bash
+    npm install @opentelemetry/exporter-trace-otlp-http
     ```
 
     ```typescript
-    new ExecutionOtelPlugin({ useDefaultTracerProvider: false });
-    new InvocationOtelPlugin({ useDefaultTracerProvider: false });
+    import { ExecutionOtelPlugin } from "@aws/durable-execution-sdk-js-otel";
+    import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+    import {
+      BatchSpanProcessor,
+      NodeTracerProvider,
+    } from "@opentelemetry/sdk-trace-node";
+
+    const plugin = new ExecutionOtelPlugin({
+      tracerProviderFactory: (createIdGenerator) => {
+        const provider = new NodeTracerProvider({
+          idGenerator: createIdGenerator(),
+          spanProcessors: [
+            new BatchSpanProcessor(
+              new OTLPTraceExporter({
+                url: "http://localhost:4318/v1/traces",
+              }),
+            ),
+          ],
+        });
+        provider.register();
+        return provider;
+      },
+    });
     ```
+
+    Substitute `InvocationOtelPlugin` to use the invocation-centered view. To
+    preserve a custom application ID generator for unrelated spans, pass it to
+    `createIdGenerator(applicationIdGenerator)`.
 
 === "Python"
 
-    `ExecutionOtelPlugin()` auto-creates a provider that exports to the collector.
-    `InvocationOtelPlugin` does not auto-create a provider. It uses the globally
-    configured provider, so with the community collector layer, pass an explicit
-    provider through `trace_provider`, or use `ExecutionOtelPlugin`.
+    Install the standalone dependencies and an OTLP HTTP exporter:
 
-    ```yaml
-    Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
-    Environment:
-      Variables:
-        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```bash
+    pip install "aws-durable-execution-sdk-python-otel[standalone]" \
+      opentelemetry-exporter-otlp-proto-http
     ```
+
+    Pass the application-owned provider through the shared configuration
+    object:
+
+    ```python
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    from aws_durable_execution_sdk_python_otel import (
+        ExecutionOtelPlugin,
+        OtelPluginConfig,
+    )
+
+    provider = TracerProvider()
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")
+        )
+    )
+
+    plugin = ExecutionOtelPlugin(
+        OtelPluginConfig(tracer_provider=provider)
+    )
+    ```
+
+    Substitute `InvocationOtelPlugin` to use the invocation-centered view.
 
 === "Java"
 
-    Do not set `AWS_LAMBDA_EXEC_WRAPPER`. Construct either plugin with a builder
-    that adds an OTLP exporter pointed at `localhost:4318`, so the plugin owns
-    its provider instead of reading the agent's.
+    Add the OpenTelemetry OTLP exporter dependency, then pass a provider builder
+    to either plugin. The plugin wraps the builder's ID generator and builds the
+    application-owned provider.
 
-    ```yaml
-    Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<collector-layer>:<version>
-    Environment:
-      Variables:
-        OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+    ```xml
+    <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-exporter-otlp</artifactId>
+        <version>${opentelemetry.version}</version>
+    </dependency>
     ```
 
     ```java
-    var exporter = OtlpHttpSpanExporter.getDefault();
-    var plugin = new ExecutionOtelPlugin(
-            SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)));
+    import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+    import io.opentelemetry.sdk.trace.SdkTracerProvider;
+    import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+    import software.amazon.lambda.durable.otel.ExecutionOtelPlugin;
+
+    var exporter = OtlpHttpSpanExporter.builder()
+            .setEndpoint("http://localhost:4318/v1/traces")
+            .build();
+
+    var providerBuilder = SdkTracerProvider.builder()
+            .addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
+
+    var plugin = new ExecutionOtelPlugin(providerBuilder);
     ```
+
+    Substitute `InvocationOtelPlugin` to use the invocation-centered view.
+
+Routing spans through a collector also lets you export to a third-party platform
+by changing the collector exporter.
 
 ## Configuration
 
 === "TypeScript"
 
-    Pass an `OtelPluginConfig` to either plugin.
+    Both plugins accept an `OtelPluginConfig` object:
 
-    - **tracerProvider** A provider to use as-is. Takes precedence over the other
-        provider options.
-    - **useDefaultTracerProvider** Use the globally registered provider, such as
-        the ADOT layer's. Defaults to `false`.
+    - **tracerProviderFactory** Creates an application-owned provider. Omit it
+        to use the global provider.
     - **contextExtractor** Extracts upstream trace context. Defaults to
         `xRayContextExtractor`. Use `w3cClientContextExtractor` for W3C
-        `traceparent` propagation. `w3cClientContextExtractor` currently does no work in Lambda.
-    - **exporterConfig** OTLP `endpoint` and `headers`, used only when the plugin
-        creates its own provider.
-    - **propagators** Replaces the default `[AWSXRay, W3CTraceContext]`
-        propagators. W3CTraceContext currently does not work in Lambda.
-    - **enableHttpInstrumentation** Registers HTTP instrumentation. Defaults to
-        `true`.
+        `traceparent` data in Lambda client context.
     - **instrumentationName** Instrumentation scope name. Defaults to
         `aws-durable-execution-sdk-js`.
     - **workflowSpanName** Name of the `Workflow` root span. Defaults to
         `Workflow`.
     - **enrichLogger** Adds `traceId`, `spanId`, and `otelTraceSampled` to each
-        durable log record through `enrichLogContext()`. Defaults to `true`.
+        durable log record. Defaults to `true`.
 
-    Control sampling with the `OTEL_DURABLE_SAMPLING_RATIO` environment variable,
-    from `0.0` to `1.0`. All invocations of one execution are sampled or dropped
-    together.
+    The application or ADOT layer owns exporters, propagators, resources,
+    sampling, and HTTP or AWS SDK instrumentation.
 
 === "Python"
 
-    `ExecutionOtelPlugin` takes an `OtelPluginConfig` dataclass with
-    `tracer_provider`, `use_default_tracer_provider`, `context_extractor`,
-    `exporter_config`, `propagators`, `enable_http_instrumentation`,
-    `instrument_name`, `workflow_span_name`, and `enrich_logger`.
+    Both plugins accept the same `OtelPluginConfig` dataclass:
 
-    `InvocationOtelPlugin` takes keyword arguments.
-
-    - **trace_provider** A tracer provider to use. Defaults to the globally
-        configured provider.
+    - **tracer_provider** Application-owned provider. Omit it to use the global
+        provider.
     - **context_extractor** Defaults to `xray_context_extractor`. Use
-        `w3c_client_context_extractor` for W3C `traceparent` propagation. W3C
-        `traceparent` propagation is currently not working in Lambda.
+        `w3c_client_context_extractor` for W3C `traceparent` data in Lambda
+        client context.
     - **instrument_name** Instrumentation scope name. Defaults to
         `aws-durable-execution-sdk-python`.
-    - **enrich_logger** Installs a root-logger filter that stamps trace context
-        onto log records. Defaults to `True`.
     - **workflow_span_name** Name of the `Workflow` root span. Defaults to
         `Workflow`.
+    - **enrich_logger** Installs a root-logger filter that stamps trace context
+        onto log records. Defaults to `True`.
 
-    Control sampling through the ADOT layer with `OTEL_TRACES_SAMPLER` and
-    `OTEL_TRACES_SAMPLER_ARG`.
+    ```python
+    plugin = InvocationOtelPlugin(
+        OtelPluginConfig(
+            instrument_name="my-service",
+            enrich_logger=False,
+        )
+    )
+    ```
 
 === "Java"
 
-    Each plugin has a no-arg constructor that uses the ADOT Java agent's global
-    provider, plus builder constructors for supplying your own provider. The
-    no-arg form requires the ADOT agent and the plugin jar registered through
-    `OTEL_JAVAAGENT_EXTENSIONS`.
+    Each plugin supports the following constructor forms:
 
     ```java
     new InvocationOtelPlugin();
+    new InvocationOtelPlugin(otelPluginConfig);
     new InvocationOtelPlugin(tracerProviderBuilder);
-    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor);
-    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc);
-    new InvocationOtelPlugin(tracerProviderBuilder, contextExtractor, enableMdc, workflowSpanName);
+    new InvocationOtelPlugin(tracerProviderBuilder, otelPluginConfig);
     ```
 
-    `ExecutionOtelPlugin` offers the same no-arg and builder constructors.
+    `ExecutionOtelPlugin` provides the same forms. The no-arg and config-only
+    constructors use the global provider. The builder constructors create an
+    application-owned provider.
 
-    - **contextExtractor** Defaults to `XRayContextExtractor`.
-    - **enableMdc** Injects `traceId`, `spanId`, and `otelTraceSampled` into the SLF4J
-        MDC. Defaults to `true`.
-    - **workflowSpanName** Name of the `Workflow` root span. Defaults to
-        `Workflow`.
+    Build `OtelPluginConfig` with:
 
-## Correlate logs with traces
+    - **contextExtractor(...)** Defaults to `new XRayContextExtractor()`.
+    - **enableMdc(...)** Adds `traceId`, `spanId`, and `otelTraceSampled` to the
+        SLF4J MDC. Defaults to `true`.
+    - **workflowSpanName(...)** Defaults to `Workflow`.
+    - **instrumentationName(...)** Defaults to
+        `aws-durable-execution-sdk-java`.
 
-The plugin stamps the active trace and span IDs onto your log records, so a log
-line in CloudWatch links to the span that emitted it. See [Logging](logging.md)
-for the SDK logger.
+    ```java
+    var config = OtelPluginConfig.builder()
+            .instrumentationName("my-service")
+            .enableMdc(false)
+            .build();
+
+    var plugin = new InvocationOtelPlugin(config);
+    ```
+
+Configure sampling through the provider. With ADOT, use the standard
+`OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables.
+
+## Load plugins dynamically
+
+The SDK can discover a plugin from a Lambda layer or installed package without
+handler registration code. Dynamic loading uses default configuration and
+therefore requires a global OpenTelemetry provider.
 
 === "TypeScript"
 
-    With `enrichLogger` enabled (the default), the plugin adds `traceId`,
-    `spanId`, and `otelTraceSampled` to each durable log record through the
+    ```text
+    DURABLE_EXECUTION_PLUGINS=@aws/durable-execution-sdk-js-otel/otel-invocation
+    ```
+
+    Use `@aws/durable-execution-sdk-js-otel/otel-execution` for the
+    workflow-centered plugin.
+
+=== "Python"
+
+    ```text
+    DURABLE_EXECUTION_PLUGINS=otel-invocation
+    ```
+
+    Use `otel-execution` for the workflow-centered plugin.
+
+=== "Java"
+
+    ```text
+    DURABLE_EXECUTION_PLUGINS=otel-invocation
+    ```
+
+    Use `otel-execution` for the workflow-centered plugin. Put the plugin JAR
+    under `java/lib` in the layer so it is on the Lambda class path.
+
+## Correlate logs with traces
+
+The plugin stamps active trace and span IDs onto log records. See
+[Logging](logging.md) for the SDK logger.
+
+=== "TypeScript"
+
+    With `enrichLogger` enabled, the plugin adds `traceId`, `spanId`, and
+    `otelTraceSampled` to each durable log record through the
     `enrichLogContext()` hook described in
     [Logging from a plugin](plugins.md#logging-from-a-plugin).
 
 === "Python"
 
-    With `enrich_logger=True` (the default), the plugin installs a filter on the
-    root logger that adds `traceId`, `spanId`, and `otelTraceSampled` to every
-    record when a span is active.
+    With `enrich_logger=True`, the plugin installs a filter on root logger
+    handlers. It adds `traceId`, `spanId`, and `otelTraceSampled` when a valid
+    span is active. Treat these fields as optional in your formatter.
 
 === "Java"
 
-    With `enableMdc=true` (the default), the plugin puts `traceId`, `spanId`, and
-    `otelTraceSampled` into the SLF4J MDC. Configure your logging framework to include
-    MDC fields in its output.
+    With `enableMdc(true)`, the plugin puts `traceId`, `spanId`, and
+    `otelTraceSampled` into the SLF4J MDC. Configure your logging framework to
+    include MDC fields in its output.
 
 ## Verify
 
-Invoke a durable function that includes a wait or a resume, so the execution runs
-across more than one invocation. In the CloudWatch console, open Traces and
-confirm the invocation and operation spans appear under one trace ID. Check that
-your log entries carry `traceId`, `spanId`, and `otelTraceSampled` matching those spans.
+Invoke a durable function that includes a wait or resume so it runs across more
+than one Lambda invocation. In CloudWatch Traces, expect:
 
-When you use the community collector layer, enable CloudWatch Transaction Search
-in your account for traces to appear. If no traces show up, the collector layer
-is missing or its configuration variable is unset. If traces fragment across
-several IDs, active tracing is off. If some operation spans are missing, the
-sampling ratio is below `1.0`.
+- A deterministic `Workflow` trace exported when the execution completes.
+- One ambient Lambda trace per invocation, containing the plugin's `Invocation`
+    span.
+- Operation links between the workflow and invocation views.
+- Log records whose trace fields match the active invocation, operation, or
+    attempt span.
+
+For Java, use the CloudWatch **Group by nodes** view to inspect the hierarchy.
+The ungrouped X-Ray Segments Timeline cannot attach OTLP-exported spans beneath
+the Lambda platform segment.
+
+When you use the community collector layer, enable CloudWatch Transaction
+Search in your account for traces to appear.
+
+If no plugin spans appear:
+
+- Confirm a provider with a span processor and exporter is registered.
+- With ADOT, confirm `AWS_LAMBDA_EXEC_WRAPPER` and active tracing are enabled.
+- With the community collector, confirm the layer and
+    `OPENTELEMETRY_COLLECTOR_CONFIG_URI` are configured.
+- For Java ADOT, confirm the plugin JAR is listed in
+    `OTEL_JAVAAGENT_EXTENSIONS`.
+- Check provider sampling configuration when only some executions appear.
 
 ## See also
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -359,13 +359,19 @@ spans when no SDK provider is registered. If TypeScript finds a registered
 tracer whose runtime ID generator is incompatible, it logs the problem once
 and continues without deterministic durable IDs.
 
-## Deploy with the community collector layer
+## Deploy with the community auto-instrumentation layer
 
-The OpenTelemetry community collector layer runs a collector extension without
-auto-instrumentation. Do not set `AWS_LAMBDA_EXEC_WRAPPER`. Configure an
-application-owned provider that exports OTLP HTTP spans to
-`http://localhost:4318/v1/traces`, and pass that provider to the plugin using the
-language-specific API below.
+Use the OpenTelemetry community language auto-instrumentation layer together
+with the community collector extension layer:
+
+- The language layer initializes auto-instrumentation and registers a global
+    OpenTelemetry provider. Set `AWS_LAMBDA_EXEC_WRAPPER` to
+    `/opt/otel-handler`.
+- The collector layer receives telemetry from that provider and exports it to
+    the configured backend.
+
+The no-arg plugin constructors use the global provider. You do not need to
+configure or pass a provider to the plugin.
 
 Include a `collector.yaml` in your function bundle and set
 `OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path:
@@ -386,7 +392,130 @@ service:
       exporters: [awsxray]
 ```
 
-Add the collector layer and configuration variable:
+Configure the language layer to export OTLP HTTP traces to the local collector.
+Disable metrics and log export if the collector configuration only defines a
+traces pipeline.
+
+Follow the
+[OpenTelemetry Lambda auto-instrumentation documentation](https://opentelemetry.io/docs/platforms/faas/lambda-auto-instrument/)
+to build or obtain the language layer. Follow the
+[collector extension documentation](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector)
+to build and publish the collector layer in your AWS account.
+
+=== "TypeScript"
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: nodejs24.x
+        Handler: index.handler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-nodejs-layer>:<version>
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+            OTEL_TRACES_EXPORTER: otlp
+            OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_METRICS_EXPORTER: none
+            OTEL_LOGS_EXPORTER: none
+            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+    ```typescript
+    new ExecutionOtelPlugin();
+    // or
+    new InvocationOtelPlugin();
+    ```
+
+=== "Python"
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: python3.14
+        Handler: index.handler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-python-layer>:<version>
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+            OTEL_TRACES_EXPORTER: otlp
+            OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_METRICS_EXPORTER: none
+            OTEL_LOGS_EXPORTER: none
+            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+    ```python
+    ExecutionOtelPlugin()
+    # or
+    InvocationOtelPlugin()
+    ```
+
+=== "Java"
+
+    Use the community Java agent layer for auto-instrumentation. The agent must
+    also load the plugin JAR as an agent extension so its auto-configuration SPI
+    can scope deterministic ID generation to durable spans. Package the JAR in
+    a layer under `java/lib`, then point `OTEL_JAVAAGENT_EXTENSIONS` to the
+    deployed path.
+
+    ```yaml
+    MyFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        Runtime: java25
+        Handler: com.example.ExampleHandler
+        Layers:
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-java-agent-layer>:<version>
+          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
+          - <otel-plugin-layer-arn>
+        Environment:
+          Variables:
+            AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+            OTEL_TRACES_EXPORTER: otlp
+            OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_METRICS_EXPORTER: none
+            OTEL_LOGS_EXPORTER: none
+            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+            OTEL_JAVAAGENT_EXTENSIONS: /opt/java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar
+        Tracing: Active
+        Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    ```
+
+    ```java
+    new ExecutionOtelPlugin();
+    // or
+    new InvocationOtelPlugin();
+    ```
+
+    To load the plugin from the layer without registering it in handler code,
+    also set `DURABLE_EXECUTION_PLUGINS` to `otel-execution` or
+    `otel-invocation`.
+
+### Collector-only setup (advanced)
+
+Use the collector extension without a language auto-instrumentation layer when
+you need to configure the OpenTelemetry provider in application code. Add only
+the collector layer, leave `AWS_LAMBDA_EXEC_WRAPPER` unset, and pass the
+application-owned provider to the plugin.
 
 ```yaml
 Layers:
@@ -395,10 +524,6 @@ Environment:
   Variables:
     OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
 ```
-
-See the
-[OpenTelemetry Lambda releases](https://github.com/open-telemetry/opentelemetry-lambda/releases)
-for current collector layer releases.
 
 === "TypeScript"
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -361,46 +361,20 @@ and continues without deterministic durable IDs.
 
 ## Deploy with the community auto-instrumentation layer
 
-Use the OpenTelemetry community language auto-instrumentation layer together
-with the community collector extension layer:
-
-- The language layer initializes auto-instrumentation and registers a global
-    OpenTelemetry provider. Set `AWS_LAMBDA_EXEC_WRAPPER` to
-    `/opt/otel-handler`.
-- The collector layer receives telemetry from that provider and exports it to
-    the configured backend.
+The OpenTelemetry community language layer initializes auto-instrumentation,
+registers a global OpenTelemetry provider, and exports spans using OTLP. Set
+`AWS_LAMBDA_EXEC_WRAPPER` to `/opt/otel-handler` and configure the OTLP endpoint
+for your observability backend.
 
 The no-arg plugin constructors use the global provider. You do not need to
 configure or pass a provider to the plugin.
 
-Include a `collector.yaml` in your function bundle and set
-`OPENTELEMETRY_COLLECTOR_CONFIG_URI` to its path:
-
-```yaml
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: "localhost:4318"
-exporters:
-  awsxray:
-    region: "${AWS_REGION}"
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [awsxray]
-```
-
-Configure the language layer to export OTLP HTTP traces to the local collector.
-Disable metrics and log export if the collector configuration only defines a
-traces pipeline.
+The examples below use OTLP HTTP and disable metrics and log export. If the
+backend requires authentication, also configure `OTEL_EXPORTER_OTLP_HEADERS`.
 
 Follow the
 [OpenTelemetry Lambda auto-instrumentation documentation](https://opentelemetry.io/docs/platforms/faas/lambda-auto-instrument/)
-to build or obtain the language layer. Follow the
-[collector extension documentation](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector)
-to build and publish the collector layer in your AWS account.
+to obtain the language layer.
 
 === "TypeScript"
 
@@ -412,16 +386,14 @@ to build and publish the collector layer in your AWS account.
         Handler: index.handler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-nodejs-layer>:<version>
-          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
             OTEL_TRACES_EXPORTER: otlp
             OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_EXPORTER_OTLP_ENDPOINT: https://<otlp-endpoint>
             OTEL_METRICS_EXPORTER: none
             OTEL_LOGS_EXPORTER: none
-            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
         Tracing: Active
         Policies:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
@@ -444,16 +416,14 @@ to build and publish the collector layer in your AWS account.
         Handler: index.handler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-python-layer>:<version>
-          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
             OTEL_TRACES_EXPORTER: otlp
             OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_EXPORTER_OTLP_ENDPOINT: https://<otlp-endpoint>
             OTEL_METRICS_EXPORTER: none
             OTEL_LOGS_EXPORTER: none
-            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
         Tracing: Active
         Policies:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
@@ -482,17 +452,15 @@ to build and publish the collector layer in your AWS account.
         Handler: com.example.ExampleHandler
         Layers:
           - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-java-agent-layer>:<version>
-          - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
           - <otel-plugin-layer-arn>
         Environment:
           Variables:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
             OTEL_TRACES_EXPORTER: otlp
             OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-            OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://localhost:4318/v1/traces
+            OTEL_EXPORTER_OTLP_ENDPOINT: https://<otlp-endpoint>
             OTEL_METRICS_EXPORTER: none
             OTEL_LOGS_EXPORTER: none
-            OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
             OTEL_JAVAAGENT_EXTENSIONS: /opt/java/lib/aws-durable-execution-sdk-java-plugin-otel-<version>.jar
         Tracing: Active
         Policies:
@@ -509,6 +477,50 @@ to build and publish the collector layer in your AWS account.
     To load the plugin from the layer without registering it in handler code,
     also set `DURABLE_EXECUTION_PLUGINS` to `otel-execution` or
     `otel-invocation`.
+
+### Add a collector extension (optional)
+
+Add the community collector extension layer when you need local processing,
+routing, or an exporter that is not available in the language layer. Keep
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` so the language layer continues to
+initialize the provider and the ambient Lambda span.
+
+Append the collector layer, point the OTLP exporter at its local receiver, and
+set the collector configuration path:
+
+```yaml
+Layers:
+  - <community-language-layer-arn>
+  - !Sub arn:aws:lambda:${AWS::Region}:<account>:layer:<community-collector-layer>:<version>
+Environment:
+  Variables:
+    AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4318
+    OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
+```
+
+For example, include the following `collector.yaml` in the function bundle to
+export traces to X-Ray:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+exporters:
+  awsxray:
+    region: "${AWS_REGION}"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [awsxray]
+```
+
+Change the collector exporter to route spans to another platform. See the
+[collector extension documentation](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector)
+for available components and layer deployment instructions.
 
 ### Collector-only setup (advanced)
 
@@ -632,9 +644,6 @@ Environment:
     ```
 
     Substitute `InvocationOtelPlugin` to use the invocation-centered view.
-
-Routing spans through a collector also lets you export to a third-party platform
-by changing the collector exporter.
 
 ## Configuration
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -208,9 +208,8 @@ Lambda invocation
 ```
 
 An operation that crosses an invocation boundary can produce more than one
-span. The portable correlation point is the `Workflow` link. Do not rely on a
-later segment containing a link to an earlier operation span because the SDK
-does not checkpoint that OpenTelemetry span context.
+span. All SDKs correlate those spans through the `Workflow` span. TypeScript may
+also emit a deterministic operation link; Python and Java do not.
 
 ### Choosing a plugin
 

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -53,10 +53,15 @@ CloudWatch.
 === "TypeScript"
 
     ```bash
-    npm install @aws/durable-execution-sdk-js-otel
+    npm install @aws/durable-execution-sdk-js-otel \
+      @opentelemetry/api \
+      @opentelemetry/core \
+      @opentelemetry/sdk-trace-node
     ```
 
-    The TypeScript plugin requires Node.js 22 or later.
+    The TypeScript plugin requires Node.js 22 or later. The OpenTelemetry
+    packages are peer dependencies used by the configured provider or telemetry
+    layer.
 
 === "Python"
 
@@ -150,12 +155,12 @@ Lambda invocation
 The operation links identify which invocation ran each part of the workflow.
 The invocation spans are not children of `Workflow`.
 
-!!! note "TypeScript application-owned provider"
+!!! note "TypeScript provider topology"
 
-    When TypeScript `ExecutionOtelPlugin` uses `tracerProviderFactory` and no
-    ambient trace exists, its `Invocation` span is created under `Workflow`.
-    The global-provider and ADOT path keeps the invocation in the ambient Lambda
-    trace as shown above.
+    TypeScript keeps the workflow and invocation views in separate traces with
+    both global and application-owned providers. The `Invocation` span uses the
+    active OpenTelemetry parent when one exists, then the extracted upstream
+    parent, and otherwise becomes a root. It is not parented to `Workflow`.
 
 ### InvocationOtelPlugin
 
@@ -208,8 +213,9 @@ Lambda invocation
 ```
 
 An operation that crosses an invocation boundary can produce more than one
-span. All SDKs correlate those spans through the `Workflow` span. TypeScript may
-also emit a deterministic operation link; Python and Java do not.
+span. All SDKs correlate those spans through the `Workflow` span. TypeScript
+replay and continuation spans use new span IDs and do not synthesize links to
+earlier operation spans.
 
 ### Choosing a plugin
 
@@ -352,12 +358,12 @@ provider option.
     `otel-invocation`.
 
 If the global SDK provider is not ready at plugin construction, the plugins
-retry provider resolution at invocation start. Python and Java disable
-telemetry for that invocation when a compatible SDK provider is still
-unavailable, then retry on the next invocation. TypeScript emits no exported
-spans when no SDK provider is registered. If TypeScript finds a registered
-tracer whose runtime ID generator is incompatible, it logs the problem once
-and continues without deterministic durable IDs.
+retry provider resolution at invocation start. All three SDKs disable telemetry
+for that invocation when a compatible SDK provider is still unavailable, then
+retry on the next invocation. In TypeScript global-provider mode, the SDK tracer
+must support installation of the scoped deterministic ID wrapper. If it does
+not, the plugin logs a warning and disables telemetry for that invocation
+instead of emitting spans without deterministic durable IDs.
 
 ## Deploy with the community auto-instrumentation layer
 
@@ -663,7 +669,7 @@ Environment:
     - **enrichLogger** Adds `traceId`, `spanId`, and `otelTraceSampled` to each
         durable log record. Defaults to `true`.
 
-    The application or ADOT layer owns exporters, propagators, resources,
+    The application or telemetry layer owns exporters, propagators, resources,
     sampling, and HTTP or AWS SDK instrumentation.
 
 === "Python"
@@ -805,6 +811,8 @@ Search in your account for traces to appear.
 If no plugin spans appear:
 
 - Confirm a provider with a span processor and exporter is registered.
+- For TypeScript, check for a warning that the global provider does not expose a
+    compatible SDK tracer.
 - With ADOT, confirm `AWS_LAMBDA_EXEC_WRAPPER` and active tracing are enabled.
 - With the community collector, confirm the layer and
     `OPENTELEMETRY_COLLECTOR_CONFIG_URI` are configured.

--- a/docs/sdk-reference/observability/opentelemetry.md
+++ b/docs/sdk-reference/observability/opentelemetry.md
@@ -155,12 +155,10 @@ Lambda invocation
 The operation links identify which invocation ran each part of the workflow.
 The invocation spans are not children of `Workflow`.
 
-!!! note "TypeScript provider topology"
-
-    TypeScript keeps the workflow and invocation views in separate traces with
-    both global and application-owned providers. The `Invocation` span uses the
-    active OpenTelemetry parent when one exists, then the extracted upstream
-    parent, and otherwise becomes a root. It is not parented to `Workflow`.
+This topology is the same in all three SDKs with both global and
+application-owned providers. The `Invocation` span uses the active
+OpenTelemetry parent when one exists, then the extracted upstream parent, and
+otherwise becomes a root.
 
 ### InvocationOtelPlugin
 
@@ -213,9 +211,9 @@ Lambda invocation
 ```
 
 An operation that crosses an invocation boundary can produce more than one
-span. All SDKs correlate those spans through the `Workflow` span. TypeScript
-replay and continuation spans use new span IDs and do not synthesize links to
-earlier operation spans.
+span. In all three SDKs, replay and continuation spans use new span IDs and
+correlate through the `Workflow` span. They do not synthesize links to earlier
+operation spans.
 
 ### Choosing a plugin
 
@@ -357,13 +355,11 @@ provider option.
     also set `DURABLE_EXECUTION_PLUGINS` to `otel-execution` or
     `otel-invocation`.
 
-If the global SDK provider is not ready at plugin construction, the plugins
-retry provider resolution at invocation start. All three SDKs disable telemetry
-for that invocation when a compatible SDK provider is still unavailable, then
-retry on the next invocation. In TypeScript global-provider mode, the SDK tracer
-must support installation of the scoped deterministic ID wrapper. If it does
-not, the plugin logs a warning and disables telemetry for that invocation
-instead of emitting spans without deterministic durable IDs.
+When the plugins use the global provider, they resolve it at invocation start.
+If a usable SDK provider or the integration required for scoped deterministic
+IDs is unavailable, all three SDKs log a warning and disable telemetry for that
+invocation. They retry provider resolution on the next invocation instead of
+emitting spans without deterministic durable IDs.
 
 ## Deploy with the community auto-instrumentation layer
 
@@ -811,8 +807,8 @@ Search in your account for traces to appear.
 If no plugin spans appear:
 
 - Confirm a provider with a span processor and exporter is registered.
-- For TypeScript, check for a warning that the global provider does not expose a
-    compatible SDK tracer.
+- Check for a warning that the global SDK provider or its deterministic ID
+    integration was unavailable at invocation start.
 - With ADOT, confirm `AWS_LAMBDA_EXEC_WRAPPER` and active tracing are enabled.
 - With the community collector, confirm the layer and
     `OPENTELEMETRY_COLLECTOR_CONFIG_URI` are configured.


### PR DESCRIPTION
## Summary

- correct the OpenTelemetry trace model to show the deterministic Workflow trace separately from ambient invocation traces
- update provider ownership, configuration, dynamic loading, and log-correlation guidance for Python main, Java PR #627, and JavaScript PR #836
- replace the removed automatic OTLP setup with runnable application-owned provider examples for the community collector layer
- update ADOT deployment and troubleshooting guidance, including Java agent extension setup

## SDK sources

- Python: https://github.com/aws/aws-durable-execution-sdk-python (main)
- Java: https://github.com/aws/aws-durable-execution-sdk-java/pull/627
- JavaScript: https://github.com/aws/aws-durable-execution-sdk-js/pull/836

## Validation

- `mdformat --check docs/sdk-reference/observability/opentelemetry.md`
- `codespell docs/sdk-reference/observability/opentelemetry.md`
- `zensical build --clean`