### PR TITLE
ci: add stale issue closer workflow

### DIFF
--- a/.github/workflows/stale-issue-closer.yml
+++ b/.github/workflows/stale-issue-closer.yml
@@ -1,0 +1,20 @@
+name: Stale Issue Closer
+
+on:
+  schedule:
+    # Avoid the top of the hour; GitHub can delay or drop scheduled workflows
+    # during high-load periods.
+    - cron: "37 12 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  close-stale:
+    permissions:
+      contents: read
+      issues: write
+    uses: aws/aws-durable-execution-ci/.github/workflows/stale-issue-closer.yml@962e6f158467681a26769b2b06da98c8f2f62231
+    with:
+      days-until-close: 14
+      close-reason: not_planned


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Adds stale issue workflow that closes issues labeled as `needs-info` after 14 days of no response
* See https://github.com/aws/aws-durable-execution-ci/pull/26 for implementation and testing details

## Testing
* Tested in a forked JS repo to confirm workflow works as intended in a consumer repo
  * https://github.com/hln33/aws-durable-execution-sdk-js/issues/2 
  * https://github.com/hln33/aws-durable-execution-sdk-js/issues/3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.